### PR TITLE
Simplify files

### DIFF
--- a/modules/ngiab_data_cli/__main__.py
+++ b/modules/ngiab_data_cli/__main__.py
@@ -35,11 +35,12 @@ def setup_logging() -> None:
     handler.setFormatter(ColoredFormatter("%(asctime)s - %(levelname)s - %(message)s"))
     logging.basicConfig(level=logging.INFO, handlers=[handler])
 
-def set_logging_to_error_only() -> None:
-    """Set logging to ERROR level only."""
-    logging.getLogger().setLevel(logging.ERROR)
-    # Explicitly set Dask's logger to ERROR level
-    logging.getLogger("distributed").setLevel(logging.ERROR)
+
+def set_logging_to_critical_only() -> None:
+    """Set logging to CRITICAL level only."""
+    logging.getLogger().setLevel(logging.CRITICAL)
+    # Explicitly set Dask's logger to CRITICAL level
+    logging.getLogger("distributed").setLevel(logging.CRITICAL)
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -163,11 +164,11 @@ def main() -> None:
             logging.info(f"Creating realization from {args.start_date} to {args.end_date}...")
             create_realization(wb_id_for_name, start_time=args.start_date, end_time=args.end_date)
             logging.info("Realization creation complete.")
-        
+
         logging.info("All requested operations completed successfully.")
         # set logging to ERROR level only as dask distributed can clutter the terminal with INFO messages
         # that look like errors
-        set_logging_to_error_only()
+        set_logging_to_critical_only()
 
     except Exception as e:
         logging.error(f"{Fore.RED}An error occurred: {str(e)}{Style.RESET_ALL}")


### PR DESCRIPTION
- Remove input file generation for geojson and json files (no longer used as ngen reads the geopackage)
- Update CLI log to CRITICAL only before dask shuts down to suppress ["random" communication errors ](https://dask.discourse.group/t/best-practice-for-shutting-down-a-cluster/1382/7)