### PR TITLE
replace /ngen/ngen/data with relative ./ for pantarhei

### DIFF
--- a/modules/data_processing/create_realization.py
+++ b/modules/data_processing/create_realization.py
@@ -169,7 +169,7 @@ def configure_troute(
         time_step_size=time_step_size,
         # troute seems to be ok with setting this to your cpu_count
         cpu_pool=multiprocessing.cpu_count(),
-        geo_file_path=f"/ngen/ngen/data/config/{cat_id}_subset.gpkg",
+        geo_file_path=f"./config/{cat_id}_subset.gpkg",
         start_datetime=start_time.strftime("%Y-%m-%d %H:%M:%S"),
         nts=nts,
         max_loop_size=nts,

--- a/modules/data_sources/cfe-nowpm-realization-template.json
+++ b/modules/data_sources/cfe-nowpm-realization-template.json
@@ -91,8 +91,8 @@
     "output_interval": 3600
   },
   "routing": {
-    "t_route_config_file_with_path": "/ngen/ngen/data/config/troute.yaml"
+    "t_route_config_file_with_path": "./config/troute.yaml"
   },
   "remotes_enabled": false,
-  "output_root": "/ngen/ngen/data/outputs/ngen"
+  "output_root": "./outputs/ngen"
 }

--- a/modules/data_sources/dd-catchment-template.yml
+++ b/modules/data_sources/dd-catchment-template.yml
@@ -6,5 +6,5 @@ initial_state: zero
 lat: {lat} # needs calulating
 lon: {lon} # needs calulating
 slope_mean: {slope_mean} # mean.slope
-train_cfg_file: /ngen/ngen/data/config/dd-config.yml
+train_cfg_file: ./config/dd-config.yml
 verbose: 0

--- a/modules/data_sources/dd-realization-template.json
+++ b/modules/data_sources/dd-realization-template.json
@@ -42,8 +42,8 @@
     "output_interval": 3600
   },
   "routing": {
-    "t_route_config_file_with_path": "/ngen/ngen/data/config/troute.yaml"
+    "t_route_config_file_with_path": "./config/troute.yaml"
   },
   "remotes_enabled": false,
-  "output_root": "/ngen/ngen/data/outputs/ngen"
+  "output_root": "./outputs/ngen"
 }


### PR DESCRIPTION
replaces the hardcoded ngiab paths with relative paths. 

As we set the working director in ngiab to /ngen/ngen/data/ we can use relative paths to make it easier to port configs over to pantarhei and other places where the directory structure may differ