### PR TITLE
Add units to forcings

### DIFF
--- a/modules/data_processing/create_realization.py
+++ b/modules/data_processing/create_realization.py
@@ -224,8 +224,6 @@ def configure_troute(
         troute_template = file.read()
     time_step_size = 300
     nts = (end_time - start_time).total_seconds() / time_step_size
-    seconds_in_hour = 3600
-    number_of_hourly_steps = nts * time_step_size / seconds_in_hour
     filled_template = troute_template.format(
         # hard coded to 5 minutes
         time_step_size=time_step_size,
@@ -234,8 +232,7 @@ def configure_troute(
         geo_file_path=f"./config/{cat_id}_subset.gpkg",
         start_datetime=start_time.strftime("%Y-%m-%d %H:%M:%S"),
         nts=nts,
-        max_loop_size=nts,
-        stream_output_time=number_of_hourly_steps,
+        max_loop_size=nts,        
     )
 
     with open(config_dir / "troute.yaml", "w") as file:

--- a/modules/data_processing/file_paths.py
+++ b/modules/data_processing/file_paths.py
@@ -97,7 +97,7 @@ class file_paths:
 
     @property
     def cached_nc_file(self) -> Path:
-        return self.subset_dir / "merged_data.nc"
+        return self.forcings_dir / "raw_gridded_data.nc"
 
     def append_cli_command(self, command: list[str]) -> None:
         current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")

--- a/modules/data_processing/file_paths.py
+++ b/modules/data_processing/file_paths.py
@@ -110,8 +110,6 @@ class file_paths:
 
     def setup_run_folders(self) -> None:
         folders = [
-            "restart",
-            "lakeout",
             "outputs",
             "outputs/ngen",
             "outputs/troute",

--- a/modules/data_processing/forcings.py
+++ b/modules/data_processing/forcings.py
@@ -320,9 +320,11 @@ def write_outputs(forcings_dir, variables, units):
 
 def setup_directories(cat_id: str) -> file_paths:
     forcing_paths = file_paths(cat_id)
-    if forcing_paths.forcings_dir.exists():
-        logger.info("Forcings directory already exists, deleting")
-        shutil.rmtree(forcing_paths.forcings_dir)
+    # delete everything in the forcing folder except the cached nc file
+    for file in forcing_paths.forcings_dir.glob("*.*"):
+        if file != forcing_paths.cached_nc_file:
+            file.unlink()
+
     os.makedirs(forcing_paths.forcings_dir / "temp", exist_ok=True)
 
     return forcing_paths

--- a/modules/data_sources/cfe-nowpm-realization-template.json
+++ b/modules/data_sources/cfe-nowpm-realization-template.json
@@ -80,7 +80,7 @@
       }
     ],
     "forcing": {
-      "path": "./forcings/by_catchment/forcings.nc",
+      "path": "./forcings/forcings.nc",
       "provider": "NetCDF",
       "enable_cache": false
     }

--- a/modules/data_sources/em-realization-template.json
+++ b/modules/data_sources/em-realization-template.json
@@ -53,7 +53,7 @@
       }
     ],
     "forcing": {
-      "path": "./forcings/by_catchment/forcings.nc",
+      "path": "./forcings/forcings.nc",
       "provider": "NetCDF",
       "enable_cache": false
     }

--- a/modules/data_sources/ngen-routing-template.yaml
+++ b/modules/data_sources/ngen-routing-template.yaml
@@ -98,12 +98,12 @@ compute_parameters:
 output_parameters:
     #----------
     #test_output: outputs/lcr_flowveldepth.pkl
-    lite_restart:
-        #----------
-        lite_restart_output_directory: restart/
-    lakeout_output: lakeout/
+    # lite_restart:
+    #     #----------
+    #     lite_restart_output_directory: restart/
+    # lakeout_output: lakeout/
     stream_output:
         stream_output_directory: outputs/troute/
-        stream_output_time: {stream_output_time} #number of internal_frequency timesteps per output file
+        stream_output_time: -1 # -1 adds all outputs to a single file
         stream_output_type: ".nc" #please select only between netcdf '.nc' or '.csv' or '.pkl'
         stream_output_internal_frequency: 60 #[min] it should be order of 5 minutes. For instance if you want to output every hour put 60


### PR DESCRIPTION
closes #69 #70 #71

- adds units to forcing.nc and a note explaining APCP_surface
- removes forcing/by_catchment folder as it no longer makes sense with a single forcing file
- renamed and moved merged_data to raw_gridded_data
- removed lakeout and restart folders, and updated troute config so it doesn't need them
- update troute timestep per file to be -1 rather than calculating it (functionally the same)