### PR TITLE
Update cfe-template.ini with new cfe1 variable names

### DIFF
--- a/modules/data_sources/cfe-template.ini
+++ b/modules/data_sources/cfe-template.ini
@@ -1,5 +1,6 @@
 forcing_file=BMI
-surface_partitioning_scheme=Schaake
+surface_water_partitioning_scheme=Schaake
+surface_runoff_scheme=GIUH
 
 # ----------------
 # State Parameters
@@ -40,11 +41,11 @@ alpha_fc=0.33
 # decimal fraction of maximum soil water storage (smcmax * depth) for the initial timestep
 soil_storage=0.05[m/m]
 # number of Nash lf reservoirs (optional, defaults to 2, ignored if storage values present)
-K_nash=0.03[]
+K_nash_subsurface=0.03[]
 # Nash Config param - primary reservoir
 K_lf=0.01[]
 # Nash Config param - secondary reservoir
-nash_storage=0.0,0.0
+nash_storage_subsurface=0.0,0.0
 # Giuh ordinates in dt time steps
 giuh_ordinates=0.55,0.25,0.2
 


### PR DESCRIPTION
Now that ngiab is built using the most up to date version of cfe, this will remove the deprecated variable names warnings.