### PR TITLE
fix gage delineation to not include downstreams

### DIFF
--- a/modules/data_processing/gpkg_utils.py
+++ b/modules/data_processing/gpkg_utils.py
@@ -69,7 +69,7 @@ def verify_indices(gpkg: str = file_paths.conus_hydrofabric) -> None:
     con.close()
 
 
-def create_empty_gpkg(gpkg: str) -> None:
+def create_empty_gpkg(gpkg: Path) -> None:
     """
     Create an empty geopackage with the necessary tables and indices.
     """
@@ -80,7 +80,7 @@ def create_empty_gpkg(gpkg: str) -> None:
         conn.executescript(sql_script)
 
 
-def add_triggers_to_gpkg(gpkg: str) -> None:
+def add_triggers_to_gpkg(gpkg: Path) -> None:
     """
     Adds geopackage triggers required to maintain spatial index integrity
     """
@@ -256,7 +256,7 @@ def insert_data(con: sqlite3.Connection, table: str, contents: List[Tuple]) -> N
     con.commit()
 
 
-def update_geopackage_metadata(gpkg: str) -> None:
+def update_geopackage_metadata(gpkg: Path) -> None:
     """
     Update the contents of the gpkg_contents table in the specified geopackage.
     """
@@ -318,10 +318,10 @@ def subset_table_by_vpu(table: str, vpu: str, hydrofabric: Path, subset_gpkg_nam
     contents = source_db.execute(sql_query).fetchall()
 
     if table == "network":
-        # Look for the network entry that has a toid not in the flowpath or nexus tables        
+        # Look for the network entry that has a toid not in the flowpath or nexus tables
         network_toids = [x[2] for x in contents]
         print(f"Network toids: {len(network_toids)}")
-        sql = "SELECT id FROM flowpaths"  
+        sql = "SELECT id FROM flowpaths"
         flowpath_ids = [x[0] for x in dest_db.execute(sql).fetchall()]
         print(f"Flowpath ids: {len(flowpath_ids)}")
         sql = "SELECT id FROM nexus"
@@ -342,8 +342,8 @@ def subset_table_by_vpu(table: str, vpu: str, hydrofabric: Path, subset_gpkg_nam
 
     dest_db.commit()
     source_db.close()
-    dest_db.close()   
-    
+    dest_db.close()
+
 
 def subset_table(table: str, ids: List[str], hydrofabric: Path, subset_gpkg_name: Path) -> None:
     """
@@ -359,7 +359,7 @@ def subset_table(table: str, ids: List[str], hydrofabric: Path, subset_gpkg_name
     source_db = sqlite3.connect(f"file:{hydrofabric}?mode=ro", uri=True)
     dest_db = sqlite3.connect(subset_gpkg_name)
 
-    table_keys = {"divides": "toid", "divide-attributes": "divide_id", "lakes": "poi_id"}
+    table_keys = {"divide-attributes": "divide_id", "lakes": "poi_id"}
 
     if table == "lakes":
         # lakes subset we get from the pois table which was already subset by water body id
@@ -377,7 +377,7 @@ def subset_table(table: str, ids: List[str], hydrofabric: Path, subset_gpkg_name
     if table in table_keys:
         key_name = table_keys[table]
     sql_query = f"SELECT * FROM '{table}' WHERE {key_name} IN ({','.join(ids)})"
-    contents = source_db.execute(sql_query).fetchall()    
+    contents = source_db.execute(sql_query).fetchall()
 
     insert_data(dest_db, table, contents)
 
@@ -429,16 +429,16 @@ def get_table_crs(gpkg: str, table: str) -> str:
 
 def get_cat_from_gage_id(gage_id: str, gpkg: Path = file_paths.conus_hydrofabric) -> str:
     """
-    Get the nexus id of associated with a gage id.
+    Get the catchment id associated with a gage id.
 
     Args:
         gage_id (str): The gage ID.
 
     Returns:
-        str: The nexus id of the watershed containing the gage ID.
+        str: The catchment id of the watershed containing the gage ID.
 
     Raises:
-        IndexError: If nexus is found for the given gage ID.
+        IndexError: If catchment is found for the given gage ID.
 
     """
     gage_id = "".join([x for x in gage_id if x.isdigit()])

--- a/modules/data_processing/graph_utils.py
+++ b/modules/data_processing/graph_utils.py
@@ -165,6 +165,10 @@ def get_upstream_cats(names: Union[str, List[str]]) -> Set[str]:
         if name in parent_ids:
             continue
         try:
+            if "cat" in name:
+                node_index = graph.vs.find(cat=name).index
+            else:
+                node_index = graph.vs.find(name=name).index
             node_index = graph.vs.find(cat=name).index
             upstream_nodes = graph.subcomponent(node_index, mode="IN")
             for node in upstream_nodes:
@@ -205,7 +209,10 @@ def get_upstream_ids(names: Union[str, List[str]], include_outlet: bool = True) 
         if name in parent_ids:
             continue
         try:
-            node_index = graph.vs.find(name=name).index
+            if "cat" in name:
+                node_index = graph.vs.find(cat=name).index
+            else:
+                node_index = graph.vs.find(name=name).index
             upstream_nodes = graph.subcomponent(node_index, mode="IN")
             for node in upstream_nodes:
                 parent_ids.add(graph.vs[node]["name"])

--- a/modules/data_processing/subset.py
+++ b/modules/data_processing/subset.py
@@ -31,7 +31,7 @@ subset_tables = [
 
 def create_subset_gpkg(
     ids: Union[List[str], str], hydrofabric: Path, output_gpkg_path: Path, is_vpu: bool = False
-) -> Path:
+):
     # ids is a list of nexus and wb ids, or a single vpu id
     if not isinstance(ids, list):
         ids = [ids]
@@ -65,10 +65,11 @@ def subset_vpu(vpu_id: str, output_gpkg_path: Path, hydrofabric: Path = file_pat
 def subset(
     cat_ids: List[str],
     hydrofabric: Path = file_paths.conus_hydrofabric,
-    output_gpkg_path: Path = None,
-) -> str:
-
-    upstream_ids = list(get_upstream_ids(cat_ids))
+    output_gpkg_path: Path = Path(),
+    include_outlet: bool = True,
+):
+    print(cat_ids)
+    upstream_ids = list(get_upstream_ids(cat_ids, include_outlet))
 
     if not output_gpkg_path:
         # if the name isn't provided, use the first upstream id
@@ -80,15 +81,3 @@ def subset(
     create_subset_gpkg(upstream_ids, hydrofabric, output_gpkg_path)
     logger.info(f"Subset complete for {len(upstream_ids)} features (catchments + nexuses)")
     logger.debug(f"Subset complete for {upstream_ids} catchments")
-
-
-def move_files_to_config_dir(subset_output_dir: str) -> None:
-    config_dir = subset_output_dir / "config"
-    config_dir.mkdir(parents=True, exist_ok=True)
-
-    files = [x for x in subset_output_dir.iterdir()]
-    for file in files:
-        if file.suffix in [".csv", ".json", ".geojson"]:
-            if "partitions" in file.name:
-                continue
-            os.system(f"mv {file} {config_dir}")

--- a/modules/ngiab_data_cli/__main__.py
+++ b/modules/ngiab_data_cli/__main__.py
@@ -147,7 +147,10 @@ def main() -> None:
                 logging.info("Subsetting complete.")
             else:
                 logging.info(f"Subsetting hydrofabric")
-                subset(feature_to_subset, output_gpkg_path=paths.geopackage_path)
+                include_outlet = True
+                if args.gage:
+                    include_outlet = False
+                subset(feature_to_subset, output_gpkg_path=paths.geopackage_path, include_outlet=include_outlet)
                 logging.info("Subsetting complete.")
 
         if args.forcings:


### PR DESCRIPTION
Now that gages have a reasonably consistent 1:1 mapping with flowpaths, we no longer need to include every flowpath connecting to the downstream nexus. e.g. excluding the grey area
![image](https://github.com/user-attachments/assets/3bd7caba-129b-4dc6-b7ef-930c19330fa2)

Adds a new `include_outlet` parameter to the subset function to enable or disable this type of delineation
True by default as that is what the code was already doing before

As well as a some type hinting cleanup