### PR TITLE
Hf download improvements

### DIFF
--- a/modules/data_processing/gpkg_utils.py
+++ b/modules/data_processing/gpkg_utils.py
@@ -92,9 +92,6 @@ def add_triggers_to_gpkg(gpkg: Path) -> None:
     logger.debug(f"Added triggers to subset gpkg {gpkg}")
 
 
-# whenever this is imported, check if the indices are correct
-if file_paths.conus_hydrofabric.is_file():
-    verify_indices()
 
 
 def blob_to_geometry(blob: bytes) -> Union[Point, Polygon]:

--- a/modules/data_sources/source_validation.py
+++ b/modules/data_sources/source_validation.py
@@ -51,9 +51,6 @@ def decompress_gzip_tar(file_path, output_dir):
                 for member in tar:
                     tar.extract(member, path=output_dir)
                     progress.update(task, advance=1 / len(tar.getmembers()))
-                    # Update the progress bar
-    # progress.update(task, completed=1)
-    # progress.stop()
 
 
 def download_from_s3(save_path, bucket=S3_BUCKET, key=S3_KEY, region=S3_REGION):
@@ -107,15 +104,6 @@ def download_from_s3(save_path, bucket=S3_BUCKET, key=S3_KEY, region=S3_REGION):
         use_threads=True,
     )
 
-    # console.print(f"Downloading {key} to {save_path}...", style="bold green")
-    # console.print(
-    #     "The file downloads faster with no progress indicator, this should take around 30s",
-    #     style="bold yellow",
-    # )
-    # console.print(
-    #     "Please use network monitoring on your computer if you wish to track the download",
-    #     style="green",
-    # )
 
     try:
         dl_progress = Progress(BarColumn(), DownloadColumn(), TransferSpeedColumn())

--- a/modules/data_sources/source_validation.py
+++ b/modules/data_sources/source_validation.py
@@ -10,6 +10,7 @@ import psutil
 import requests
 from boto3.s3.transfer import TransferConfig
 from botocore.exceptions import ClientError
+import botocore
 from data_processing.file_paths import file_paths
 from rich.console import Console
 from rich.progress import (Progress, 
@@ -64,10 +65,13 @@ def download_from_s3(save_path, bucket=S3_BUCKET, key=S3_KEY, region=S3_REGION):
     if os.path.exists(save_path):
         console.print(f"File already exists: {save_path}", style="bold yellow")
         os.remove(save_path)
-
+    
+    client_config = botocore.config.Config(
+        max_pool_connections=75
+    )
     # Initialize S3 client
     s3_client = boto3.client(
-        "s3", aws_access_key_id="", aws_secret_access_key="", region_name=region
+        "s3", aws_access_key_id="", aws_secret_access_key="", region_name=region, config=client_config
     )
     # Disable request signing for public buckets
     s3_client._request_signer.sign = lambda *args, **kwargs: None


### PR DESCRIPTION
See issue #105 

- Added rich progress bar to hydrofabric download 
- Automatically redownloads hydrofabric if `verify_indices()` raises an exception. Had to shuffle functions around so that we didn't have nested rich live displays (aka the rich status for the import statements in main -> rich progress bar during an automated hydrofabric download triggered by broken hydrofabric). 
- Increased boto connection pool size so we didn't get 5 bazillion warnings

Left out the implementation of chunkrs