### PR TITLE
Ensure a space after commandPrefix on all platforms

### DIFF
--- a/modules/map_app/templates/index.html
+++ b/modules/map_app/templates/index.html
@@ -57,6 +57,10 @@
                 document.getElementById('copy-to-clip').addEventListener('click', async function() {
                     const commandPrefix = document.getElementById('cli-prefix').textContent;
                     const commandText = document.getElementById('cli-command').textContent;
+                    if (commandPrefix && !commandPrefix.endsWith(' ')) {
+                        // Ensure there's a space after the prefix
+                        commandPrefix += ' ';
+                    }
                     const full_command = commandPrefix + commandText;
                     const button = this;
 


### PR DESCRIPTION
Pull request to solve #125 

Copy issue may have been a result of parsing differences between browsers, as it occurred on Firefox while not occurring on Google Chrome or Microsoft Edge.

## Problem Summary:

On some platforms, when copying the produced command on the `map_app`, the two segments (`cli-prefix` and `cli-command`) would be improperly concatenated due to a missing space and produce an invalid command.

## Proposed Solution:

A quick change to `modules/map_app/templates/index.html`, inserting a small conditional to ensure the space is not lost.

![Code_irTrYavdh1](https://github.com/user-attachments/assets/52d8e04a-49d5-4ec4-af6b-171bcaa0bcb6)

Since the original space only disappears on certain platforms, conditionally re-adding it avoids some pitfalls while ensuring it continues to work on those platforms.
