### PR TITLE
lumped in graph pickle file download with hf download

### DIFF
--- a/modules/data_sources/source_validation.py
+++ b/modules/data_sources/source_validation.py
@@ -168,7 +168,7 @@ def download_and_update_hf():
     )
 
 def validate_hydrofabric():
-    if not file_paths.conus_hydrofabric.is_file() or not file_paths.hydrofabric_graph.is_file():
+    if not file_paths.conus_hydrofabric.is_file():
         response = Prompt.ask(
             "Hydrofabric files are missing. Would you like to download them now?",
             default="y",


### PR DESCRIPTION
See issue #121 : after the user agrees to the hydrofabric download, the hydrofabric downloads, the pickled graph file downloads immediately afterward, and then the hydrofabric tar file is unzipped.