### PR TITLE
disable overwrite check

### DIFF
--- a/modules/data_processing/subset.py
+++ b/modules/data_processing/subset.py
@@ -2,8 +2,6 @@ import logging
 import os
 from pathlib import Path
 from typing import List, Union
-from rich.prompt import Prompt
-from rich.console import Console
 
 from data_processing.file_paths import file_paths
 from data_processing.gpkg_utils import (
@@ -14,6 +12,8 @@ from data_processing.gpkg_utils import (
     update_geopackage_metadata,
 )
 from data_processing.graph_utils import get_upstream_ids
+from rich.console import Console
+from rich.prompt import Prompt
 
 logger = logging.getLogger(__name__)
 console = Console()
@@ -32,7 +32,11 @@ subset_tables = [
 
 
 def create_subset_gpkg(
-    ids: Union[List[str], str], hydrofabric: Path, output_gpkg_path: Path, is_vpu: bool = False, override_gpkg: bool = False
+    ids: Union[List[str], str],
+    hydrofabric: Path,
+    output_gpkg_path: Path,
+    is_vpu: bool = False,
+    override_gpkg: bool = True,
 ):
     # ids is a list of nexus and wb ids, or a single vpu id
     if not isinstance(ids, list):
@@ -55,7 +59,7 @@ def create_subset_gpkg(
     else:
         if os.path.exists(output_gpkg_path):
             os.remove(output_gpkg_path)
-            
+
     create_empty_gpkg(output_gpkg_path)
     logger.info(f"Subsetting tables: {subset_tables}")
     for table in subset_tables:
@@ -94,7 +98,7 @@ def subset(
     hydrofabric: Path = file_paths.conus_hydrofabric,
     output_gpkg_path: Path = Path(),
     include_outlet: bool = True,
-    override_gpkg: bool = False # only gets set to true through map app
+    override_gpkg: bool = True,
 ):
     upstream_ids = list(get_upstream_ids(cat_ids, include_outlet))
 


### PR DESCRIPTION
temporarily disabling the subset overwrite check to allow us to keep releasing main without breaking compatibility of scripts using uvx