### PR TITLE
fixed request url and added warning for failed GET request

### DIFF
--- a/modules/data_processing/create_realization.py
+++ b/modules/data_processing/create_realization.py
@@ -263,6 +263,8 @@ def create_realization(
             with open(template_path, "w") as f:
                 json.dump(new_template, f)
             logger.info(f"downloaded calibrated parameters for {gage_id}")
+        else:
+            logger.warning(f"could not download parameters for {gage_id}, using default template")
 
     conf_df = get_model_attributes(paths.geopackage_path)
 

--- a/modules/ngiab_data_cli/__main__.py
+++ b/modules/ngiab_data_cli/__main__.py
@@ -60,6 +60,8 @@ def validate_input(args: argparse.Namespace) -> Tuple[str, str]:
         logging.info(f"Found {feature_name} from {input_feature}")
     elif args.gage:
         validate_hydrofabric()
+        if not input_feature.startswith("gage-"):
+            input_feature = "gage-" + input_feature
         feature_name = get_cat_from_gage_id(input_feature)
         logging.info(f"Found {feature_name} from {input_feature}")
     else:
@@ -69,6 +71,8 @@ def validate_input(args: argparse.Namespace) -> Tuple[str, str]:
         output_folder = args.output_name
         validate_output_dir()
     elif args.gage:
+        if not input_feature.startswith("gage-"):
+            input_feature = "gage-" + input_feature
         output_folder = input_feature
         validate_output_dir()
     else:
@@ -186,6 +190,8 @@ def main() -> None:
             gage_id = None
             if args.gage:
                 gage_id = args.input_feature
+                if not gage_id.startswith("gage-"):
+                    gage_id = "gage-" + gage_id
             if args.lstm:
                 create_lstm_realization(
                     output_folder, start_time=args.start_date, end_time=args.end_date


### PR DESCRIPTION
addresses issue #143 

basically the issue was that the url would build without the "gage-" prefix in the gage id section and then no calibrated parameters would download

I also fixed the naming convention for the output folder so we wouldn't get two separate folders when subsetting by the same gage but using different commands. So `uvx ngiab-prep -i 12345678 -g -s` and `uvx ngiab-prep -i gage-12345678 -s` will now both output to the same folder, instead of to `ngiab_preprocess_output/12345678` and `ngiab_preprocess_output/gage-12345678`, respectively.