### PR TITLE
Output root folder

### DIFF
--- a/modules/ngiab_data_cli/__main__.py
+++ b/modules/ngiab_data_cli/__main__.py
@@ -140,11 +140,11 @@ def main() -> None:
         if args.debug:
             logging.getLogger("data_processing").setLevel(logging.DEBUG)
 
-        if args.change_output_dir:
+        if args.change_root_dir:
             config_file_path = os.path.expanduser("~/.ngiab/")
             with open(os.path.join(config_file_path, "preprocessor"), "w") as config_file:
-                config_file.write(args.change_output_dir)
-            logging.info(f"Changed default directory where outputs are stored to {args.change_output_dir}")
+                config_file.write(args.change_root_dir)
+            logging.info(f"Changed default directory where outputs are stored to {args.change_root_dir}")
 
         feature_to_subset, output_folder = validate_input(args)
 

--- a/modules/ngiab_data_cli/arguments.py
+++ b/modules/ngiab_data_cli/arguments.py
@@ -12,6 +12,13 @@ def parse_arguments() -> argparse.Namespace:
         description="Subsetting hydrofabrics, forcing generation, and realization creation"
     )
     group = parser.add_mutually_exclusive_group(required=True)
+
+    parser.add_argument(
+        "--change_output_dir",
+        type=str,
+        help="Path to new default directory where outputs in the future will be stored",
+    )
+
     group.add_argument(
         "-i",
         "--input_feature",
@@ -97,7 +104,7 @@ def parse_arguments() -> argparse.Namespace:
         "-o",
         "--output_name",
         type=str,
-        help="Name of the output folder",
+        help="Custom data output folder name in lieu of the default, which is the ID of the input feature",
     )
     parser.add_argument(
         "-D",

--- a/modules/ngiab_data_cli/arguments.py
+++ b/modules/ngiab_data_cli/arguments.py
@@ -14,7 +14,7 @@ def parse_arguments() -> argparse.Namespace:
     group = parser.add_mutually_exclusive_group(required=False)
 
     parser.add_argument(
-        "--change_output_dir",
+        "--change_root_dir",
         type=str,
         help="Path to new default directory where outputs in the future will be stored",
     )

--- a/modules/ngiab_data_cli/arguments.py
+++ b/modules/ngiab_data_cli/arguments.py
@@ -11,7 +11,7 @@ def parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Subsetting hydrofabrics, forcing generation, and realization creation"
     )
-    group = parser.add_mutually_exclusive_group(required=True)
+    group = parser.add_mutually_exclusive_group(required=False)
 
     parser.add_argument(
         "--change_output_dir",


### PR DESCRIPTION
See issue #152 
Added CLI argument `--change_root_dir` and set `group = parser.add_mutually_exclusive_group(required=False)`. In this way, a user can use the CLI to change their default root folder without having to preprocess any data. (I could do some kind of `argparse` wrangling with `subparsers` if we want to change the structure of the CLI).

<img width="992" height="162" alt="Screenshot 2025-08-26 at 2 30 00 PM" src="https://github.com/user-attachments/assets/0253755f-95d4-491e-b1d6-7ea6bd41c5c6" />
