### PR TITLE
add rust lstm option

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+# Title
+
+## Bug Fixed / Feature Added
+
+## How it was fixed / implemented
+
+## Testing / Screenshots

--- a/modules/data_processing/create_realization.py
+++ b/modules/data_processing/create_realization.py
@@ -231,11 +231,26 @@ def make_ngen_realization_json(
         json.dump(realization, file, indent=4)
 
 
-def create_lstm_realization(cat_id: str, start_time: datetime, end_time: datetime):
+def create_lstm_realization(
+    cat_id: str, start_time: datetime, end_time: datetime, use_rust: bool = False
+):
     paths = FilePaths(cat_id)
-    template_path = FilePaths.template_lstm_realization_config
+    realization_path = paths.config_dir / "realization.json"
     configure_troute(cat_id, paths.config_dir, start_time, end_time)
-    make_ngen_realization_json(paths.config_dir, template_path, start_time, end_time)
+    # python version of the lstm
+    python_template_path = FilePaths.template_lstm_realization_config
+    make_ngen_realization_json(paths.config_dir, python_template_path, start_time, end_time)
+    realization_path.rename(paths.config_dir / "python_lstm_real.json")
+    # rust version of the lstm
+    rust_template_path = FilePaths.template_lstm_rust_realization_config
+    make_ngen_realization_json(paths.config_dir, rust_template_path, start_time, end_time)
+    realization_path.rename(paths.config_dir / "rust_lstm_real.json")
+
+    if use_rust:
+        (paths.config_dir / "rust_lstm_real.json").rename(realization_path)
+    else:
+        (paths.config_dir / "python_lstm_real.json").rename(realization_path)
+
     make_lstm_config(paths.geopackage_path, paths.config_dir)
     # create some partitions for parallelization
     paths.setup_run_folders()

--- a/modules/data_processing/file_paths.py
+++ b/modules/data_processing/file_paths.py
@@ -29,6 +29,7 @@ class FilePaths:
     template_troute_config = data_sources / "ngen-routing-template.yaml"
     template_cfe_nowpm_realization_config = data_sources / "cfe-nowpm-realization-template.json"
     template_lstm_realization_config = data_sources / "lstm-realization-template.json"
+    template_lstm_rust_realization_config = data_sources / "lstm-rust-realization-template.json"
     template_noahowp_config = data_sources / "noah-owp-modular-init.namelist.input"
     template_cfe_config = data_sources / "cfe-template.ini"
     template_lstm_config = data_sources / "lstm-catchment-template.yml"

--- a/modules/data_sources/lstm-rust-realization-template.json
+++ b/modules/data_sources/lstm-rust-realization-template.json
@@ -1,0 +1,47 @@
+{
+  "global": {
+    "formulations": [
+      {
+        "name": "bmi_multi",
+        "params": {
+          "name": "bmi_multi",
+          "model_type_name": "lstm",
+          "forcing_file": "",
+          "init_config": "",
+          "allow_exceed_end_time": true,
+          "main_output_variable": "land_surface_water__runoff_depth",
+          "modules": [
+            {
+              "name": "bmi_c",
+              "params": {
+                "name": "bmi_c",
+                "model_type_name": "bmi_rust",
+                "init_config": "./config/cat_config/lstm/{{id}}.yml",
+                "allow_exceed_end_time": true,
+                "main_output_variable": "land_surface_water__runoff_depth",
+                "uses_forcing_file": false,
+                "registration_function": "register_bmi_lstm",
+                "library_file": "/dmod/shared_libs/libbmi_burn_lstm.so"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "forcing": {
+      "path": "./forcings/forcings.nc",
+      "provider": "NetCDF",
+      "enable_cache": false
+    }
+  },
+  "time": {
+    "start_time": "2016-01-01 00:00:00",
+    "end_time": "2016-02-27 00:00:00",
+    "output_interval": 3600
+  },
+  "routing": {
+    "t_route_config_file_with_path": "./config/troute.yaml"
+  },
+  "remotes_enabled": false,
+  "output_root": "./outputs/ngen"
+}

--- a/modules/ngiab_data_cli/__main__.py
+++ b/modules/ngiab_data_cli/__main__.py
@@ -39,9 +39,9 @@ def validate_input(args: argparse.Namespace) -> Tuple[str, str]:
 
     if args.input_feature:
         input_feature = args.input_feature.replace("_", "-")
-      
-        if args.gage and not input_feature.startswith("gage-") :
-          input_feature = "gage-" + input_feature
+
+        if args.gage and not input_feature.startswith("gage-"):
+            input_feature = "gage-" + input_feature
 
         # look at the prefix for autodetection, if -g or -l is used then there is no prefix
         if len(input_feature.split("-")) > 1:
@@ -76,7 +76,7 @@ def validate_input(args: argparse.Namespace) -> Tuple[str, str]:
             validate_output_dir()
         elif args.gage:
             output_folder = input_feature
-            validate_output_dir()            
+            validate_output_dir()
         else:
             output_folder = feature_name
             validate_output_dir()
@@ -209,9 +209,12 @@ def main() -> None:
                 gage_id = args.input_feature
                 if not gage_id.startswith("gage-"):
                     gage_id = "gage-" + gage_id
-            if args.lstm:
+            if args.lstm or args.lstm_rust:
                 create_lstm_realization(
-                    output_folder, start_time=args.start_date, end_time=args.end_date
+                    output_folder,
+                    start_time=args.start_date,
+                    end_time=args.end_date,
+                    use_rust=args.lstm_rust,
                 )
             else:
                 create_realization(

--- a/modules/ngiab_data_cli/arguments.py
+++ b/modules/ngiab_data_cli/arguments.py
@@ -112,10 +112,16 @@ def parse_arguments() -> argparse.Namespace:
         action="store_true",
         help="enable debug logging",
     )
-    parser.add_argument(
+    lstm_group = parser.add_mutually_exclusive_group(required=False)
+    lstm_group.add_argument(
         "--lstm",
         action="store_true",
         help="enable LSTM model realization and forcings",
+    )
+    lstm_group.add_argument(
+        "--lstm_rust",
+        action="store_true",
+        help="enable experimental high speed Rust bindings of LSTM model realization and forcings",
     )
     parser.add_argument(
         "--nwm_gw",


### PR DESCRIPTION
adds additional option --lstm_rust which uses a realization that runs the rust lstm instead of the python lstm

if --lstm is used then `realization.json` contains python config and `rust_lstm_real.json' contains the rust realization
if --lstm_rust is used then ' realization.json contains rust config and 'python_lstm_real.json' contains the python config

ngiab uses the wildcard config/*realization*.json to find realizations so we must avoid matching that pattern with more than one file to avoid breaking automatic realization selection.
