### PR TITLE
save output_root as absolute path

### DIFF
--- a/modules/ngiab_data_cli/__main__.py
+++ b/modules/ngiab_data_cli/__main__.py
@@ -9,6 +9,7 @@ with rich.status.Status("loading") as status:
     import subprocess
     import time
     from multiprocessing import cpu_count
+    from pathlib import Path
 
     import geopandas as gpd
     from data_processing.create_realization import create_lstm_realization, create_realization
@@ -143,7 +144,7 @@ def main() -> None:
 
         if args.output_root:
             with open(FilePaths.config_file, "w") as config_file:
-                config_file.write(args.output_root)
+                config_file.write(str(Path(args.output_root).expanduser().absolute()))
             logging.info(
                 f"Changed default directory where outputs are stored to {args.output_root}"
             )


### PR DESCRIPTION
now if you set --output_root to something relative like `.` it won't create folders all over the place if you use the command from somewhere else

<img width="1093" height="760" alt="image" src="https://github.com/user-attachments/assets/2ead467d-cf5b-413f-9d5b-b2169691d476" />
