### PR TITLE
pin netcdf4 to 1.7.2 max

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "s3fs==2024.3.1",
     "xarray==2024.2.0",
     "zarr==2.17.1",
-    "netCDF4>=1.6.5",
+    "netCDF4>=1.6.5,<1.7.3",
     "dask==2024.4.1",
     "dask[distributed]==2024.4.1",
     "h5netcdf==1.3.0",


### PR DESCRIPTION
1.7.3 has broken forcing processing

# Broken
normal uvx ngiab-prep ...
<img width="1327" height="350" alt="image" src="https://github.com/user-attachments/assets/9dc6abad-b568-48e8-8481-a7bcf2bacb9f" />

# Working
<img width="1181" height="507" alt="image" src="https://github.com/user-attachments/assets/b3e6571e-7d7d-44cf-8a8e-a61ba96f762c" />

