### PR TITLE
compute lazy dask array before passing to xr interp function

### DIFF
--- a/modules/data_processing/forcings.py
+++ b/modules/data_processing/forcings.py
@@ -312,7 +312,6 @@ def get_units(dataset: xr.Dataset) -> dict:
             units[var] = dataset[var].attrs["units"]
     return units
 
-
 def interpolate_nan_values(
     dataset: xr.Dataset,
     dim: str = "time",
@@ -345,7 +344,7 @@ def interpolate_nan_values(
         if not var.isnull().any().compute():
             continue
         logger.info("Interpolating NaN values in %s", name)
-
+        var = var.compute()
         dataset[name] = var.interpolate_na(
             dim=dim,
             method=method,


### PR DESCRIPTION
See issue #167 

Turns out the `apply_ufunc` error within `xr.interpolate_na` occurs if whatever is passed to it is a lazily loaded dask array, not just if a dask client is on. So I just made the dataarray with NaNs compute itself before passing it to the xarray interpolation function. Obviously this results in a performance decrease, but I think it's a small price to pay to automatically handle NaNs within the data preprocessor.

Tested with the command mentioned in issue #167 