### PR TITLE
pin h5py to <= 3.11 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
     "boto3",
     "numcodecs<0.16.0",
     "scipy>=1.15.3",
+    "h5py<=3.11"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
some machines are still getting a netcdf error processing forcings e.g. pantarhei, pinning this fixes it 