### PR TITLE
save the raw_gridded_data as zarr instead of netcdf

### DIFF
--- a/modules/data_processing/dataset_utils.py
+++ b/modules/data_processing/dataset_utils.py
@@ -1,8 +1,9 @@
 import logging
 import os
+import shutil
 from datetime import datetime
 from pathlib import Path
-from typing import Literal, Tuple, Union
+from typing import Tuple, Union
 
 import geopandas as gpd
 import numpy as np
@@ -115,46 +116,48 @@ def clip_dataset_to_bounds(
     logger.info("Selected time range and clipped to bounds")
     return dataset
 
+
 @temp_cluster
 def save_dataset(
     ds_to_save: xr.Dataset,
     target_path: Path,
-    engine: Literal["netcdf4", "scipy", "h5netcdf"] = "h5netcdf",
 ):
     """
     Helper function to compute and save an xarray.Dataset (specifically, the raw
-    forcing data) to a NetCDF file.
+    forcing data) to a Zarr archive.
     Uses a temporary file and rename for atomicity.
     """
     if not target_path.parent.exists():
         target_path.parent.mkdir(parents=True, exist_ok=True)
 
-    temp_file_path = target_path.with_name(target_path.name + ".saving.nc")
+    temp_file_path = target_path.with_suffix(".saving.zarr")
     if temp_file_path.exists():
-        os.remove(temp_file_path)
+        shutil.rmtree(temp_file_path)
+
+    for var in ds_to_save.data_vars:
+        chunks = [max(chunk_lens) for chunk_lens in ds_to_save[var].chunks]
+        ds_to_save[var] = ds_to_save[var].chunk(chunks)
 
     client = Client.current()
-    future: Future = client.compute(
-        ds_to_save.to_netcdf(temp_file_path, engine=engine, compute=False)
-    )  # type: ignore
+    future: Future = client.compute(ds_to_save.to_zarr(temp_file_path, compute=False))  # type: ignore
     logger.debug(
-        f"NetCDF write task submitted to Dask. Waiting for completion to {temp_file_path}..."
+        f"Zarr write task submitted to Dask. Waiting for completion to {temp_file_path}..."
     )
     logger.info("For more detailed progress, see the Dask dashboard http://localhost:8787/status")
     progress(future)
     future.result()
-    os.rename(str(temp_file_path), str(target_path))
+    if target_path.exists():
+        shutil.rmtree(target_path)
+    temp_file_path.rename(target_path)
     logger.info(f"Successfully saved data to: {target_path}")
 
 
 @no_cluster
-def save_to_cache(
-    stores: xr.Dataset, cached_nc_path: Path
-) -> xr.Dataset:
+def save_to_cache(stores: xr.Dataset, cached_zarr_path: Path) -> xr.Dataset:
     """
-    Compute the store and save it to a cached netCDF file. This is not required but will save time and bandwidth.
+    Compute the store and save it to a cached Zarr archive. This is not required but will save time and bandwidth.
     """
-    logger.debug(f"Processing dataset for caching. Final cache target: {cached_nc_path}")
+    logger.debug(f"Processing dataset for caching. Final cache target: {cached_zarr_path}")
 
     # lasily cast all numbers to f32
     for name, var in stores.data_vars.items():
@@ -162,14 +165,14 @@ def save_to_cache(
             stores[name] = var.astype("float32", casting="same_kind")
 
     # save dataset locally before manipulating it
-    save_dataset(stores, cached_nc_path)
+    save_dataset(stores, cached_zarr_path)
 
-    stores = xr.open_mfdataset(cached_nc_path, parallel=True, engine="h5netcdf")
+    stores = xr.open_mfdataset(cached_zarr_path, parallel=True, engine="zarr")
     return stores
 
 
 def check_local_cache(
-    cached_nc_path: Path,
+    cached_zarr_path: Path,
     start_time: str,
     end_time: str,
     gdf: gpd.GeoDataFrame,
@@ -177,13 +180,13 @@ def check_local_cache(
 ) -> Union[xr.Dataset, None]:
     merged_data = None
 
-    if not os.path.exists(cached_nc_path):
+    if not os.path.exists(cached_zarr_path):
         logger.info("No cache found")
         return
 
-    logger.info("Found cached nc file")
+    logger.info("Found cached zarr archive")
     # open the cached file and check that the time range is correct
-    cached_data = xr.open_mfdataset(cached_nc_path, parallel=True, engine="h5netcdf")
+    cached_data = xr.open_mfdataset(cached_zarr_path, parallel=True, engine="zarr")
 
     if "name" not in cached_data.attrs or "name" not in remote_dataset.attrs:
         logger.warning("No name attribute found to compare datasets")
@@ -211,7 +214,7 @@ def check_local_cache(
 
     if range_in_cache:
         logger.info("Time range is within cached data")
-        logger.debug(f"Opened cached nc file: [{cached_nc_path}]")
+        logger.debug(f"Opened cached zarr archive: [{cached_zarr_path}]")
         merged_data = clip_dataset_to_bounds(cached_data, gdf.total_bounds, start_time, end_time)
         logger.debug("Clipped stores")
 

--- a/modules/data_processing/file_paths.py
+++ b/modules/data_processing/file_paths.py
@@ -100,8 +100,8 @@ class FilePaths:
         return self.config_dir / f"{self.folder_name}_subset.gpkg"
 
     @property
-    def cached_nc_file(self) -> Path:
-        return self.forcings_dir / "raw_gridded_data.nc"
+    def cached_zarr_file(self) -> Path:
+        return self.forcings_dir / "raw_gridded_data.zarr"
 
     def append_cli_command(self, command: list[str]) -> None:
         current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")

--- a/modules/data_processing/forcings.py
+++ b/modules/data_processing/forcings.py
@@ -312,6 +312,7 @@ def get_units(dataset: xr.Dataset) -> dict:
             units[var] = dataset[var].attrs["units"]
     return units
 
+
 def interpolate_nan_values(
     dataset: xr.Dataset,
     dim: str = "time",
@@ -561,7 +562,7 @@ def setup_directories(cat_id: str) -> FilePaths:
     forcing_paths = FilePaths(cat_id)
     # delete everything in the forcing folder except the cached nc file
     for file in forcing_paths.forcings_dir.glob("*.*"):
-        if file != forcing_paths.cached_nc_file:
+        if file != forcing_paths.cached_zarr_file:
             file.unlink()
 
     os.makedirs(forcing_paths.forcings_dir / "temp", exist_ok=True)

--- a/modules/map_app/views.py
+++ b/modules/map_app/views.py
@@ -1,9 +1,8 @@
 import json
 import logging
+import threading
 from datetime import datetime
 from pathlib import Path
-import os
-import threading
 
 import geopandas as gpd
 from data_processing.create_realization import create_realization
@@ -11,7 +10,7 @@ from data_processing.dataset_utils import save_and_clip_dataset
 from data_processing.datasets import load_aorc_zarr, load_v3_retrospective_zarr
 from data_processing.file_paths import FilePaths
 from data_processing.forcings import create_forcings
-from data_processing.graph_utils import get_upstream_cats, get_upstream_ids
+from data_processing.graph_utils import get_upstream_ids
 from data_processing.subset import subset
 from flask import Blueprint, jsonify, render_template, request
 
@@ -24,6 +23,7 @@ logger = logging.getLogger(__name__)
 @main.route("/")
 def index():
     return render_template("index.html")
+
 
 # this subset does not include the downstream nexus
 @main.route("/get_upstream_catids", methods=["POST"])
@@ -39,6 +39,7 @@ def get_upstream_catids():
     if cat_id in cleaned_upstreams:
         cleaned_upstreams.remove(cat_id)
     return list(cleaned_upstreams), 200
+
 
 # this subset includes the downstream nexus
 @main.route("/get_upstream_wbids", methods=["POST"])
@@ -65,12 +66,12 @@ def subset_check():
     if run_paths.geopackage_path.exists():
         return str(run_paths.geopackage_path), 409
     else:
-        return "no conflict",200
+        return "no conflict", 200
 
 
 @main.route("/subset", methods=["POST"])
 def subset_selection():
-    #body: JSON.stringify({ 'cat_id': [cat_id], 'subset_type': subset_type})
+    # body: JSON.stringify({ 'cat_id': [cat_id], 'subset_type': subset_type})
     data = json.loads(request.data.decode("utf-8"))
     cat_ids = data.get("cat_id")
     subset_type = data.get("subset_type")
@@ -82,7 +83,12 @@ def subset_selection():
     if subset_type == "nexus":
         subset(cat_ids, output_gpkg_path=run_paths.geopackage_path, override_gpkg=True)
     else:
-        subset(cat_ids, output_gpkg_path=run_paths.geopackage_path, include_outlet=False, override_gpkg=True)
+        subset(
+            cat_ids,
+            output_gpkg_path=run_paths.geopackage_path,
+            include_outlet=False,
+            override_gpkg=True,
+        )
     return str(run_paths.geopackage_path), 200
 
 
@@ -100,6 +106,7 @@ def subset_to_file():
         f.write("\n".join(total_subset))
     return str(subset_paths.subset_dir), 200
 
+
 @main.route("/make_forcings_progress_file", methods=["POST"])
 def make_forcings_progress_file():
     data = json.loads(request.data.decode("utf-8"))
@@ -110,18 +117,20 @@ def make_forcings_progress_file():
         json.dump({"total_steps": 0, "steps_completed": 0}, f)
     return str(paths.forcing_progress_file), 200
 
+
 @main.route("/forcings_progress", methods=["POST"])
 def forcings_progress_endpoint():
     progress_file = Path(json.loads(request.data.decode("utf-8")))
     with open(progress_file, "r") as f:
         forcings_progress = json.load(f)
-    forcings_progress_all = forcings_progress['total_steps']
-    forcings_progress_completed = forcings_progress['steps_completed']
+    forcings_progress_all = forcings_progress["total_steps"]
+    forcings_progress_completed = forcings_progress["steps_completed"]
     try:
         percent = int((forcings_progress_completed / forcings_progress_all) * 100)
     except ZeroDivisionError:
         percent = "NaN"
     return str(percent), 200
+
 
 def download_forcings(data_source, start_time, end_time, paths):
     if data_source == "aorc":
@@ -131,12 +140,14 @@ def download_forcings(data_source, start_time, end_time, paths):
     else:
         raise ValueError(f"Unknown data source: {data_source}")
     gdf = gpd.read_file(paths.geopackage_path, layer="divides")
-    cached_data = save_and_clip_dataset(raw_data, gdf, start_time, end_time, paths.cached_nc_file)
+    cached_data = save_and_clip_dataset(raw_data, gdf, start_time, end_time, paths.cached_zarr_file)
     return cached_data
+
 
 def compute_forcings(cached_data, paths):
     create_forcings(cached_data, paths.output_dir.stem)  # type: ignore
-    
+
+
 @main.route("/forcings", methods=["POST"])
 def get_forcings():
     # body: JSON.stringify({'forcing_dir': forcing_dir, 'start_time': start_time, 'end_time': end_time}),
@@ -163,10 +174,10 @@ def get_forcings():
 
     cached_data = download_forcings(data_source, start_time, end_time, paths)
     # threading implemented so that main process can periodically poll progress file
-    thread = threading.Thread(target=compute_forcings,
-                              args=(cached_data, paths))
+    thread = threading.Thread(target=compute_forcings, args=(cached_data, paths))
     thread.start()
     return "started", 200
+
 
 @main.route("/realization", methods=["POST"])
 def get_realization():

--- a/modules/ngiab_data_cli/__main__.py
+++ b/modules/ngiab_data_cli/__main__.py
@@ -194,7 +194,7 @@ def main() -> None:
                 data = load_v3_retrospective_zarr()
             gdf = gpd.read_file(paths.geopackage_path, layer="divides")
             cached_data = save_and_clip_dataset(
-                data, gdf, args.start_date, args.end_date, paths.cached_nc_file
+                data, gdf, args.start_date, args.end_date, paths.cached_zarr_file
             )
 
             create_forcings(

--- a/modules/ngiab_data_cli/forcing_cli.py
+++ b/modules/ngiab_data_cli/forcing_cli.py
@@ -80,8 +80,8 @@ def main() -> None:
     start_time = args.start_date.strftime("%Y-%m-%d %H:%M")
     end_time = args.end_date.strftime("%Y-%m-%d %H:%M")
 
-    cached_nc_path = args.output_file.parent / (args.input_file.stem + "-raw-gridded-data.nc")
-    print(cached_nc_path)
+    cached_zarr_path = args.output_file.parent / (args.input_file.stem + "-raw-gridded-data.nc")
+    print(cached_zarr_path)
     if args.source == "aorc":
         data = load_aorc_zarr(args.start_date.year, args.end_date.year)
     elif args.source == "nwm":
@@ -89,11 +89,11 @@ def main() -> None:
 
     gdf = gdf.to_crs(data.crs)
 
-    cached_data = check_local_cache(cached_nc_path, start_time, end_time, gdf, data)
+    cached_data = check_local_cache(cached_zarr_path, start_time, end_time, gdf, data)
 
     if not cached_data:
         clipped_data = clip_dataset_to_bounds(data, gdf.total_bounds, start_time, end_time)
-        cached_data = save_to_cache(clipped_data, cached_nc_path)
+        cached_data = save_to_cache(clipped_data, cached_zarr_path)
 
     forcing_working_dir = args.output_file.parent / (args.input_file.stem + "-working-dir")
     if not forcing_working_dir.exists():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
     "netCDF4>=1.6.5,<1.7.3",
     "dask==2024.4.1",
     "dask[distributed]==2024.4.1",
-    "h5netcdf==1.3.0",
     "exactextract==0.2.0",
     "numpy>=1.26.4",
     "tqdm==4.66.4",
@@ -53,7 +52,6 @@ dependencies = [
     "boto3",
     "numcodecs<0.16.0",
     "scipy>=1.15.3",
-    "h5py<=3.11"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
saving it as zarr seems to reduce the file size down to ~20% of the netcdf, it runs faster, and reduces the amount of operations that get added to the dask task graph which makes it more stable at downloading larger quantities of data.

a more nuclear option than #172 but we should do this regardless at some point. also should finally close out #107 #132 

needs a more testing