### PR TITLE
fixed latitude order

### DIFF
--- a/modules/data_processing/forcings.py
+++ b/modules/data_processing/forcings.py
@@ -575,5 +575,5 @@ def create_forcings(dataset: xr.Dataset, output_folder_name: str) -> None:
     gdf = gpd.read_file(forcing_paths.geopackage_path, layer="divides")
     logger.debug(f"gdf  bounds: {gdf.total_bounds}")
     gdf = gdf.to_crs(dataset.crs)
-    dataset = dataset.isel(y=slice(None, None, -1)) # flip y coordinate to match geospatial orientation
+    dataset = dataset.isel(y=slice(None, None, -1)) # Flip y-axis: source data has y ordered from top-to-bottom (as in image arrays), but geospatial operations expect y to increase from bottom-to-top (increasing latitude).
     compute_zonal_stats(gdf, dataset, forcing_paths.forcings_dir)


### PR DESCRIPTION
Addresses issue #174 

Small latitudes are to the geographic south, and big latitudes are to the geographic north. However, our DataArrays/Numpy rasters were laid out with values corresponding to small latitudes at the top of the raster grid, and vice versa. So this leads to upside-down aggregated forcings.

This fix simply flips the order of the values of the y-coordinate (the latitude coordinate).

Here's some results of my testing on the Logan River Basin using this command. This isn't the exact date range used in the examples in the linked issue, but a year is long enough to see the appropriate precip patterns.
`python -m ngiab_data_cli -i gage-10109001 -sf --start 2021-10-01 --end 2022-09-30`

For all graphics below, more saturation corresponds to more precipitation

Average precip in raw gridded data overlaid over outline of the basin, which the authors of the issue have identified as correct:
<img width="488" height="498" alt="Screenshot 2025-11-04 at 9 18 05 AM" src="https://github.com/user-attachments/assets/bcc347af-584f-4d61-898a-00c15daeb722" />

Average precip per catchment **before**  the fix -- this corresponds to the pattern identified in the issue as incorrect:
<img width="550" height="551" alt="Screenshot 2025-11-04 at 8 46 15 AM" src="https://github.com/user-attachments/assets/f79be7dc-ae1f-47b7-a356-a913bb225759" />

Average precip per catchment **after** the fix -- this corresponds to the pattern identified in the issue as correct:
<img width="466" height="475" alt="Screenshot 2025-11-04 at 9 26 05 AM" src="https://github.com/user-attachments/assets/d8f000dc-5184-417d-b2eb-769ebb82fbf9" />
