### PR TITLE
Fix manual command copying by preventing divider newline

### DIFF
--- a/modules/map_app/templates/index.html
+++ b/modules/map_app/templates/index.html
@@ -58,8 +58,8 @@
                     </button>
                 </div>
                 <div id="command-builder">
-                    <div id="cli-prefix" class="command-content">uvx --from ngiab_data_preprocess cli </div>
-                    <div id="cli-command" class="command-content"></div>
+                    <span id="cli-prefix" class="command-content">uvx --from ngiab_data_preprocess cli </span>
+                    <span id="cli-command" class="command-content"></span>
                 </div>
             </div>
             <script>


### PR DESCRIPTION
# Fix manual command copying by preventing divider newline

## Bug Fixed

If the provided CLI command was copied manually (on some browsers?), the copied string would contain a newline between the prefix and arguments, breaking the command.

## How it was fixed

By swapping the `cli-prefix` and `cli-command` from `div` to `span`, we prevent the implicit newlines.

i.e. Div elements are always assumed to start on new lines, similar to paragraphs, regardless of their visual appearance.
Spans, by contrast, are inline and do not imply new text blocks.

## Testing / Screenshots

<img width="951" height="122" alt="image" src="https://github.com/user-attachments/assets/220de28c-2210-49b9-8a01-406e1ae3b66e" />

Tested by copying both manually and with the copy button, then pasting to an empty notepad. 

Before this change, the manual copy would always result in a disjointed string, while the copy button worked correctly.
After, both function correctly.

## Potential issues

This is an extremely minimal change, with next to no potential for unexpected side effects. 

No code references these elements by their type- even the CSS references them explicitly by id. 

There is a chance of an unexpected difference in styling between the div and span types on certain platforms. 
This could result in an unintentional visual change, but since much of the styling is defined in the CSS, most relevant default style values will be overridden regardless.