### PR TITLE
fixed subset button in map app

### DIFF
--- a/modules/map_app/static/js/data_processing.js
+++ b/modules/map_app/static/js/data_processing.js
@@ -21,15 +21,11 @@ async function subset() {
             }
         }
         // check what kind of subset
-        // get the position of the subset toggle
-        // false means subset by nexus, true means subset by catchment
         if (document.getElementById('radio-nexus').checked) {
             var subset_type = 'nexus'
         } else {
             var subset_type = 'catchment'
         }
-        // var nexus_catchment = document.getElementById('radio-nexus').checked;
-        // var subset_type = nexus_catchment ? 'catchment' : 'nexus';
 
         const startTime = performance.now(); // Start the timer
         fetch('/subset', {


### PR DESCRIPTION
## Bug Fixed / Feature Added

When the new menu layout was introduced, the subset button stopped working. Partially addresses issue #180 

## How it was fixed / implemented

The javascript code was previously referencing an HTML element that no longer exists in the new layout. The referenced element IDs have been updated.

## Testing / Screenshots
tested on macOS and linux on chrome, safari, and firefox
Both subset by nexus and subset by catchment outputs were tested and inspected using qgis