### PR TITLE
fixed weird toggle behavior

### DIFF
--- a/modules/map_app/static/css/toggle.css
+++ b/modules/map_app/static/css/toggle.css
@@ -79,7 +79,7 @@
 .toggle-input:checked + .toggle-label .toggle-text-left {
     color: #888; /* Grey color for non-selected text */
 }
-  
+
 .toggle-input:checked + .toggle-label .toggle-text-right {
     color: #888; /* Grey color for non-selected text */
 }
@@ -91,7 +91,7 @@
   top: -40px;
 }
 
-.menu-switch__input {
+#menuToggle .menu-switch__input {
   opacity: 0;
   width: 100%;
   height: 100%;
@@ -162,7 +162,7 @@
         height: 1.4em;
         position: relative;
         top: -0.2em;
-        margin-right: 1em; 
+        margin-right: 1em;
         vertical-align: top;
         cursor: pointer;
         text-align: center;


### PR DESCRIPTION
## Bug Fixed / Feature Added
The toggles in the new menu layout in the map app had some unexpected behavior (see issue #182)

## How it was fixed / implemented
The invisible checkboxes behind the toggles were too large and overlapped multiple toggles, which meant that clicking on one toggle might trigger changes in different toggles. The checkboxes have now been resized appropriately

## Testing / Screenshots
tested on chrome, safari, and firefox