### PR TITLE
More CLI subsetting options

### DIFF
--- a/modules/ngiab_data_cli/__main__.py
+++ b/modules/ngiab_data_cli/__main__.py
@@ -51,6 +51,11 @@ def validate_input(args: argparse.Namespace) -> Tuple[str, str]:
     if args.input_feature:
         if args.latlon and args.gage:
             raise ValueError("Cannot use both --latlon and --gage options at the same time.")
+        
+        if len(args.input_feature) == 1 and Path(args.input_feature[0]).is_file():
+            with open(args.input_feature[0], "r") as f:
+                args.input_feature = [line.strip() for line in f if line.strip()]
+            logging.debug(f"Read {len(args.input_feature)} features from {args.input_feature}")
 
         for input_feature in args.input_feature:
             input_feature = input_feature.replace("_", "-")

--- a/modules/ngiab_data_cli/arguments.py
+++ b/modules/ngiab_data_cli/arguments.py
@@ -57,6 +57,13 @@ def parse_arguments() -> argparse.Namespace:
             "18",
         ],
     )
+    group.add_argument(
+        "-b",
+        "--bounds",
+        type=str,
+        nargs=2,
+        help="Two lat,lon corners defining a bounding rectangle inside which to select features"
+    )
 
     parser.add_argument(
         "-l",
@@ -70,6 +77,13 @@ def parse_arguments() -> argparse.Namespace:
         "--gage",
         action="store_true",
         help="Use gage ID instead of catid, expects a single gage ID via the cli \n e.g. python -m ngiab_data_cli -i 01646500 -g -s",
+    )
+    parser.add_argument(
+        "--bounds-operation",
+        type=str,
+        help="The operation to use when selecting features by bounding box (default is \"intersects\")",
+        choices=["intersects","within"],
+        default="intersects"
     )
     parser.add_argument(
         "-s",

--- a/modules/ngiab_data_cli/arguments.py
+++ b/modules/ngiab_data_cli/arguments.py
@@ -24,6 +24,7 @@ def parse_arguments() -> argparse.Namespace:
         "--input_feature",
         "--input_file",
         type=str,
+        nargs='+',
         help="ID of feature to subset, providing a prefix will automatically convert to catid, \n e.g. cat-5173 or gage-01646500 or wb-1234",
     )
     group.add_argument(

--- a/modules/ngiab_data_cli/arguments.py
+++ b/modules/ngiab_data_cli/arguments.py
@@ -25,7 +25,9 @@ def parse_arguments() -> argparse.Namespace:
         "--input_file",
         type=str,
         nargs='+',
-        help="ID of feature to subset, providing a prefix will automatically convert to catid, \n e.g. cat-5173 or gage-01646500 or wb-1234",
+        help="ID of feature to subset, providing a prefix will automatically convert to catid, \n e.g. cat-5173 or gage-01646500 or wb-1234. \
+May include multiple space-separated IDs as arguments. \
+If exactly one argument is provided and the argument is an existing file, the file will be read and each line must contain a feature ID.",
     )
     group.add_argument(
         "--vpu",


### PR DESCRIPTION
# Additional Subset Selection Options

This is somewhat draft to gage interest/input. They target the CLI, but these options could be added to the GUI as well.

These options may not all make 100% sense by themselves, but I am working up to something; the goal is to cut a small, non-hydrologically-independent domain out and use https://github.com/mattw-nws/CopyCat for filling the boundary conditions. Integration code for that is coming a little later, but I have a PoC working here now.

## Allows subset selection based on new criteria

1. Specify multiple feature ID options to `-i` directly on the CLI
2. Provide a file path to `-i` including a list of IDs, one per line
3. Provide a lat,lon bounding box (pair of coordinates), selecting all catchments either intersecting or fully within the box (code is there to support an arbitrary polygon, e.g. political boundary or HUC at a later date)

## How it was fixed / implemented

Basically extended existing options and functions. I believe the interaction with the existing options is sensible. Some additional documentation is probably needed.

## Testing / Screenshots

```
python -m ngiab_data_cli -sfr --output_root=~/ngiab_test --output_name=KY20220726_in --start 2022-07-26 --end 2022-07-28 -i cat-814110 cat-814111
```

```
python -m ngiab_data_cli -sfr --output_root=~/ngiab_test --output_name=KY20220726 --start 2022-07-26 --end 2022-07-28 --bounds 36.82,-84.156 37.972,-82.199 --bounds-operation within
```
