### PR TITLE
Make `get_cat_to_nhd_feature_id` return lowest reach

### DIFF
--- a/modules/data_processing/gpkg_utils.py
+++ b/modules/data_processing/gpkg_utils.py
@@ -530,7 +530,7 @@ def get_cat_to_nhd_feature_id(gpkg: Path = FilePaths.conus_hydrofabric) -> Dict[
         )
 
     table_name = list(tables)[0]
-    sql_query = f"SELECT divide_id, hf_id FROM {table_name} WHERE divide_id IS NOT NULL AND hf_id IS NOT NULL"
+    sql_query = f"SELECT divide_id, hf_id FROM {table_name} WHERE divide_id IS NOT NULL AND hf_id IS NOT NULL ORDER BY hf_hydroseq DESC"
 
     with sqlite3.connect(gpkg) as conn:
         result: List[Tuple[str, str]] = conn.execute(sql_query).fetchall()
@@ -539,6 +539,7 @@ def get_cat_to_nhd_feature_id(gpkg: Path = FilePaths.conus_hydrofabric) -> Dict[
     for cat, feature in result:
         # the ids are stored as floats this converts to int to match nwm output
         # numeric ids should be stored as strings.
+        # Because of the ORDER BY above, the lowest hf_hydroseq "wins"
         mapping[cat] = int(feature)
 
     return mapping


### PR DESCRIPTION
# Make `get_cat_to_nhd_feature_id` return lowest (most downstream) reach within a catchment
....according to the network table/crosswalk data.

## Bug Fixed / Feature Added

Currently, the return value of `get_cat_to_nhd_feature_id` is _some_ NHD reach within the hydrofabric catchment, but which one is technically undefined.

## How it was fixed / implemented

Assuming that `hf_hydroseq` in the network table corresponds to HydroSeq in the [NHD Data Dictionary](https://www.usgs.gov/ngp-standards-and-specifications/national-hydrography-dataset-nhd-data-dictionary-flowline-value), this change should make the returned reach ID always be the most downstream in a catchment (there may be outlier catchments where there are unconnected reaches leading to unexpected results). At the least, this should make the reach returned by `get_cat_to_nhd_feature_id` consistent where it may be inconsistent now, especially if the network table in a subset is rebuilt in a different order.

Selection of the most downstream reach should (usually) correspond most closely to the outflow nexus, which is important for some use cases.

## Testing / Screenshots


