### PR TITLE
Dask workers specification from CLI and env conf file

### DIFF
--- a/modules/data_processing/dask_utils.py
+++ b/modules/data_processing/dask_utils.py
@@ -1,8 +1,39 @@
 import logging
+import os
 
 from dask.distributed import Client
 
 logger = logging.getLogger(__name__)
+
+
+def _env_n_workers():
+    # Set workers from an environment variable, if it is a valid integer.
+    value = os.environ.get("NGIAB_DASK_WORKERS")
+    if value:
+        try:
+            return int(value)
+        except ValueError:
+            logger.warning("Invalid NGIAB_DASK_WORKERS=%r, ignoring", value)
+    return None
+
+
+# Variable to store the number of workers
+_n_workers = _env_n_workers()
+
+
+# set n_workers from CLI or other code
+def set_n_workers(n_workers):
+    """Set the number of workers used whenever this package creates a Dask cluster."""
+    global _n_workers
+    _n_workers = n_workers
+
+
+# replace of Client()
+def _new_client():
+    # If not set from the environment, the number of workers will be determined by Dask's defaults.
+    if _n_workers is not None:
+        logger.info("Starting Dask cluster with %d workers", _n_workers)
+    return Client(n_workers=_n_workers)
 
 
 def shutdown_cluster():
@@ -55,7 +86,7 @@ def use_cluster(func):
         try:
             client = Client.current()
         except ValueError:
-            client = Client()
+            client = _new_client()
         result = func(*args, **kwargs)
         return result
 
@@ -83,7 +114,7 @@ def temp_cluster(func):
             client = Client.current()
         except ValueError:
             cluster_was_running = False
-            client = Client()
+            client = _new_client()
         result = func(*args, **kwargs)
         if not cluster_was_running:
             client.shutdown()

--- a/modules/ngiab_data_cli/__main__.py
+++ b/modules/ngiab_data_cli/__main__.py
@@ -111,7 +111,9 @@ def set_dependent_flags(args, paths: FilePaths):
     # realization and forcings require subset to have been run at least once
     if args.realization or args.forcings:
         if not paths.config_dir.exists() and not args.subset:
-            logging.warning("Subset required for forcings and realization generation, enabling subset.")
+            logging.warning(
+                "Subset required for forcings and realization generation, enabling subset."
+            )
             args.subset = True
 
     if (args.forcings or args.realization) and not (args.start_date and args.end_date):
@@ -154,7 +156,9 @@ def main() -> None:
         if args.output_root:
             with open(FilePaths.config_file, "w") as config_file:
                 config_file.write(str(Path(args.output_root).expanduser().absolute()))
-            logging.info(f"Changed default directory where outputs are stored to {args.output_root}")
+            logging.info(
+                f"Changed default directory where outputs are stored to {args.output_root}"
+            )
 
         feature_to_subset, output_folder = validate_input(args)
 
@@ -201,7 +205,9 @@ def main() -> None:
             elif args.source == "nwm":
                 data = load_v3_retrospective_zarr()
             gdf = gpd.read_file(paths.geopackage_path, layer="divides")
-            cached_data = save_and_clip_dataset(data, gdf, args.start_date, args.end_date, paths.cached_nc_file)
+            cached_data = save_and_clip_dataset(
+                data, gdf, args.start_date, args.end_date, paths.cached_nc_file
+            )
 
             create_forcings(
                 cached_data,

--- a/modules/ngiab_data_cli/__main__.py
+++ b/modules/ngiab_data_cli/__main__.py
@@ -21,7 +21,7 @@ with rich.status.Status("loading") as status:
         create_snow17_realization,
         create_sacsma_realization,
     )
-    from data_processing.dask_utils import shutdown_cluster
+    from data_processing.dask_utils import set_n_workers, shutdown_cluster
     from data_processing.dataset_utils import save_and_clip_dataset
     from data_processing.datasets import load_aorc_zarr, load_v3_retrospective_zarr
     from data_processing.file_paths import FilePaths
@@ -147,6 +147,9 @@ def main() -> None:
         args = parse_arguments()
         if args.debug:
             logging.getLogger("data_processing").setLevel(logging.DEBUG)
+
+        if args.dask_workers:
+            set_n_workers(args.dask_workers)
 
         if args.output_root:
             with open(FilePaths.config_file, "w") as config_file:

--- a/modules/ngiab_data_cli/arguments.py
+++ b/modules/ngiab_data_cli/arguments.py
@@ -180,6 +180,12 @@ def parse_arguments() -> argparse.Namespace:
         action="store_true",
         help="Run all operations: subset, forcings, realization, and run Next Gen",
     )
+    parser.add_argument(
+        "--dask-workers",
+        type=int,
+        default=None,
+        help="Number of Dask workers for forcings/data processing (default: auto)",
+    )
 
     args = parser.parse_args()
 

--- a/modules/ngiab_data_cli/arguments.py
+++ b/modules/ngiab_data_cli/arguments.py
@@ -92,13 +92,21 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--start_date",
         "--start",
-        type=lambda s: datetime.strptime(s, DATE_FORMAT) if len(s) == 10 else datetime.strptime(s, DATE_FORMAT2),
+        type=lambda s: (
+            datetime.strptime(s, DATE_FORMAT)
+            if len(s) == 10
+            else datetime.strptime(s, DATE_FORMAT2)
+        ),
         help=f"Start date for forcings/realization (format {DATE_FORMAT_HINT})",
     )
     parser.add_argument(
         "--end_date",
         "--end",
-        type=lambda s: datetime.strptime(s, DATE_FORMAT) if len(s) == 10 else datetime.strptime(s, DATE_FORMAT2),
+        type=lambda s: (
+            datetime.strptime(s, DATE_FORMAT)
+            if len(s) == 10
+            else datetime.strptime(s, DATE_FORMAT2)
+        ),
         help=f"End date for forcings/realization (format {DATE_FORMAT_HINT})",
     )
     parser.add_argument(
@@ -156,10 +164,18 @@ def parse_arguments() -> argparse.Namespace:
         action="store_true",
         help="use NWM retrospective output groundwater level for CFE initial gw state",
     )
-    parser.add_argument("--run", action="store_true", help="Automatically run Next Gen against the output folder")
-    parser.add_argument("--validate", action="store_true", help="Run every missing step required to run ngiab")
-    parser.add_argument("--eval", action="store_true", help="Evaluate perforance of the model after running")
-    parser.add_argument("--vis", "--visualise", action="store_true", help="Visualize the model output")
+    parser.add_argument(
+        "--run", action="store_true", help="Automatically run Next Gen against the output folder"
+    )
+    parser.add_argument(
+        "--validate", action="store_true", help="Run every missing step required to run ngiab"
+    )
+    parser.add_argument(
+        "--eval", action="store_true", help="Evaluate perforance of the model after running"
+    )
+    parser.add_argument(
+        "--vis", "--visualise", action="store_true", help="Visualize the model output"
+    )
     parser.add_argument(
         "--source",
         type=str,

--- a/modules/ngiab_data_cli/forcing_cli.py
+++ b/modules/ngiab_data_cli/forcing_cli.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from pathlib import Path
 
 import geopandas as gpd
-from data_processing.dask_utils import shutdown_cluster
+from data_processing.dask_utils import set_n_workers, shutdown_cluster
 from data_processing.dataset_utils import check_local_cache, clip_dataset_to_bounds, save_to_cache
 from data_processing.datasets import load_aorc_zarr, load_v3_retrospective_zarr
 from data_processing.forcings import compute_zonal_stats
@@ -64,6 +64,12 @@ def parse_arguments() -> argparse.Namespace:
         action="store_true",
         help="enable debug logging",
     )
+    parser.add_argument(
+        "--dask-workers",
+        type=int,
+        default=None,
+        help="Number of Dask workers for forcings/data processing (default: auto)",
+    )
 
     return parser.parse_args()
 
@@ -73,6 +79,9 @@ def main() -> None:
     setup_logging()
     validate_all()
     args = parse_arguments()
+
+    if args.dask_workers:
+        set_n_workers(args.dask_workers)
 
     gdf = gpd.read_file(args.input_file, layer="divides")
     logging.debug(f"gdf  bounds: {gdf.total_bounds}")


### PR DESCRIPTION
# Set number of workers for Dask via CLI or env config file

I had issues with the zonal statistics where the process froze, getting the following error message (indicating a Dask distributed memory failure):

```
2026-06-17 14:56:46,965 - distributed.scheduler - ERROR - Couldn't gather keys: {('any-aggregate-83f806d56b78063eb22aaaba6485b71d',): 'memory'}
2026-06-17 14:56:46,969 - distributed.client - WARNING - Couldn't gather 1 keys, rescheduling (('any-aggregate-83f806d56b78063eb22aaaba6485b71d',),)
2026-06-17 14:57:16,978 - distributed.scheduler - ERROR - Couldn't gather keys: {('any-aggregate-83f806d56b78063eb22aaaba6485b71d',): 'memory'}
2026-06-17 14:57:16,982 - distributed.client - WARNING - Couldn't gather 1 keys, rescheduling (('any-aggregate-83f806d56b78063eb22aaaba6485b71d',),)
```

The issue was fixed after setting the number of workers manually

## Feature Added

This PR adds the capability to set Dask's number of workers by either an environmental conf file or via CLI

## How it was implemented

Changing the default `Client()` initialization to `Client(n_workers=_n_workers)` where `_n_workers` can be either `None` (default value, same behavior as before the change) or an integer.

## Testing 

Setting manually the workers get reflected in the print statements:

```python
python -m ngiab_data_cli  -i gage-02342500 -sfr --start 2020-01-01 --end 2020-01-07 --source aorc --dask-workers 8

2026-06-18 14:12:55,726 - INFO - Getting catid for 02342500, in /Users/aldotapia/.ngiab/hydrofabric/v2.2/conus_nextgen.gpkg
2026-06-18 14:12:55,729 - INFO - Found cat-483124 from gage-02342500
2026-06-18 14:12:55,730 - INFO - Processing cat-483124 in /Users/aldotapia/ngiab_preprocess_output/gage-02342500
2026-06-18 14:12:56,067 - INFO - Upstream catchments: 105
2026-06-18 14:12:56,067 - INFO - Subsetting hydrofabric
2026-06-18 14:12:56,111 - INFO - Subsetting tables: ['divides', 'divide-attributes', 'flowpath-attributes', 'flowpath-attributes-ml', 'flowpaths', 'hydrolocations', 'nexus', 'pois', 'lakes', 'network']
2026-06-18 14:12:57,297 - INFO - Subset complete for 259 features (catchments + nexuses)
2026-06-18 14:12:57,297 - INFO - Subsetting complete.
2026-06-18 14:12:57,297 - INFO - Generating forcings from 2020-01-01 00:00:00 to 2020-01-07 00:00:00...
2026-06-18 14:12:57,297 - INFO - Starting Dask cluster with 8 workers
2026-06-18 14:12:58,162 - INFO - Loading AORC zarr datasets from 2020 to2020
2026-06-18 14:12:58,162 - INFO - This should take roughly 3.5 seconds
2026-06-18 14:13:02,650 - INFO - No cache found
2026-06-18 14:13:02,654 - INFO - Selected time range and clipped to bounds
2026-06-18 14:13:02,947 - INFO - Starting Dask cluster with 8 workers
2026-06-18 14:13:03,928 - INFO - For more detailed progress, see the Dask dashboard http://localhost:8787/status
2026-06-18 14:13:09,160 - INFO - Successfully saved data to: /Users/aldotapia/ngiab_preprocess_output/gage-02342500/forcings/raw_gridded_data.nc
2026-06-18 14:13:09,645 - INFO - Computing zonal stats in parallel for all timesteps
2026-06-18 14:13:10,579 - INFO - Total steps: 8, Number of time chunks: 1, Number of variables: 8
Forcings processed in 6.257902 seco… 10… …   Elapsed Ti…  Remaining Tim… 
2026-06-18 14:13:16,838 - INFO - Forcing generation complete! Zonal stats computed in 7.192855 seconds
2026-06-18 14:13:16,838 - INFO - Starting Dask cluster with 8 workers
2026-06-18 14:13:18,935 - INFO - Saving to disk
2026-06-18 14:13:19,993 - INFO - Forcings generation complete.
2026-06-18 14:13:19,993 - INFO - Creating realization from 2020-01-01 00:00:00 to 2020-01-07 00:00:00...
2026-06-18 14:13:20,461 - INFO - downloaded calibrated parameters for gage-02342500
2026-06-18 14:13:20,510 - INFO - Realization creation complete.
2026-06-18 14:13:20,510 - INFO - All operations completed successfully.
2026-06-18 14:13:20,510 - INFO - Output folder: file:////Users/aldotapia/ngiab_preprocess_output/gage-02342500
```