### PR TITLE
Fix output_name path handling

### DIFF
--- a/modules/data_processing/create_realization.py
+++ b/modules/data_processing/create_realization.py
@@ -340,7 +340,8 @@ def configure_troute(
     with open(FilePaths.template_troute_config, "r") as file:
         troute_template = file.read()
     time_step_size = 300
-    gpkg_file_path = f"{config_dir}/{cat_id}_subset.gpkg"
+    output_name = Path(cat_id).name
+    gpkg_file_path = config_dir / f"{output_name}_subset.gpkg"
     nts = (end_time - start_time).total_seconds() / time_step_size
     with sqlite3.connect(gpkg_file_path) as conn:
         ncats_df = pandas.read_sql_query("SELECT COUNT(id) FROM 'divides';", conn)
@@ -368,7 +369,7 @@ def configure_troute(
         time_step_size=time_step_size,
         # troute seems to be ok with setting this to your cpu_count
         cpu_pool=multiprocessing.cpu_count(),
-        geo_file_path=f"./config/{cat_id}_subset.gpkg",
+        geo_file_path=f"./config/{output_name}_subset.gpkg",
         start_datetime=start_time.strftime("%Y-%m-%d %H:%M:%S"),
         nts=nts,
         max_loop_size=max_loop_size,

--- a/modules/data_processing/file_paths.py
+++ b/modules/data_processing/file_paths.py
@@ -64,11 +64,18 @@ class FilePaths:
         if (not folder_name and not output_dir) or (folder_name and output_dir):
             raise ValueError("please pass either folder_name or output_dir")
         if folder_name:
-            self.folder_name = folder_name
-            self.output_dir = self.root_output_dir() / folder_name
+            folder_path = Path(folder_name).expanduser()
+
+            if folder_path.is_absolute() or folder_path.parent != Path("."):
+                self.output_dir = folder_path.resolve()
+                self.folder_name = folder_path.name
+            else:
+                self.folder_name = folder_name
+                self.output_dir = self.root_output_dir() / folder_name
+
         if output_dir:
-            self.output_dir = Path(output_dir)
-            self.folder_name = self.output_dir.stem
+            self.output_dir = Path(output_dir).expanduser().resolve()
+            self.folder_name = self.output_dir.name
 
     @classmethod
     def get_working_dir(cls) -> Path | None:


### PR DESCRIPTION
## Summary

- Fix `--output_name` to correctly handle absolute paths as output directories.
- Preserve existing behavior for relative output folder names.
- Fix GeoPackage path construction during realization generation when using path-based output directories.

## Testing

- ✅ `--output_name output_test`
- ✅ `--output_name /tmp/output_test`

Both cases completed successfully and generated the expected outputs.

Fixes issue #207
