### PR TITLE
Cli implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, modular-configs, casam]
+    branches: [main, modular-configs, casam, other-realizations]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/modules/ngiab_data_cli/__main__.py
+++ b/modules/ngiab_data_cli/__main__.py
@@ -28,6 +28,11 @@ with rich.status.Status("loading") as status:
     from data_processing.forcings import create_forcings
     from data_processing.gpkg_utils import get_cat_from_gage_id, get_catid_from_point
     from data_processing.graph_utils import get_upstream_cats
+    from data_processing.modular_realization import (
+        validate_models,
+        create_modular_realization,
+        create_modular_configs
+    )
     from data_processing.subset import subset, subset_vpu
     from data_sources.source_validation import validate_hydrofabric, validate_output_dir
     from ngiab_data_cli.arguments import parse_arguments
@@ -39,6 +44,9 @@ def validate_input(args: argparse.Namespace) -> Tuple[str, str]:
 
     feature_name = None
     output_folder = None
+
+    if args.models:
+        validate_models(args.models, args.routing)
 
     if args.vpu:
         if not args.output_name:
@@ -256,6 +264,21 @@ def main() -> None:
                     start_time=args.start_date,
                     end_time=args.end_date,
                     gage_id=gage_id,
+                )
+            elif args.models:
+                create_modular_realization(
+                    output_folder,
+                    start_time=args.start_date,
+                    end_time=args.end_date,
+                    models=args.models,
+                    routing=args.routing,
+                )
+                create_modular_configs(
+                    output_folder,
+                    start_time=args.start_date,
+                    end_time=args.end_date,
+                    models=args.models,
+                    routing=args.routing,
                 )
             else:
                 create_realization(

--- a/modules/ngiab_data_cli/arguments.py
+++ b/modules/ngiab_data_cli/arguments.py
@@ -121,6 +121,8 @@ def parse_arguments() -> argparse.Namespace:
         action="store_true",
         help="enable debug logging",
     )
+
+    # model flags, mutually exclusive
     models = parser.add_mutually_exclusive_group(required=False)
 
     models.add_argument(
@@ -157,6 +159,32 @@ def parse_arguments() -> argparse.Namespace:
         "--sacsma",
         action="store_true",
         help="enable SAC-SMA model realization and forcings",
+    )
+
+    # user can pass list of models to run to create custom coupling
+    models.add_argument(
+        "--models",
+        type=str,
+        nargs="+",
+        help="List of models to couple together in the order of executionß, e.g. --models sloth nom cfe",
+        choices=[
+            "sloth",
+            "nom",
+            "cfe",
+            "lstm",
+            "lstm_rust",
+            "dhbv2",
+            "dhbv2_daily",
+            "snow17",
+            "sac-sma",
+            "casam",
+        ],
+    )
+
+    parser.add_argument(
+        "--routing",
+        action="store_true",
+        help="enable routing when running with custom coupled models",
     )
 
     parser.add_argument(

--- a/modules/ngiab_data_cli/arguments.py
+++ b/modules/ngiab_data_cli/arguments.py
@@ -166,7 +166,7 @@ def parse_arguments() -> argparse.Namespace:
         "--models",
         type=str,
         nargs="+",
-        help="List of models to couple together in the order of executionß, e.g. --models sloth nom cfe",
+        help="List of models to couple together in the order of execution, e.g. --models sloth nom cfe",
         choices=[
             "sloth",
             "nom",
@@ -184,7 +184,7 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--routing",
         action="store_true",
-        help="enable routing when running with custom coupled models",
+        help="enable routing when running with custom coupled models. Note this this will not activate without --models",
     )
 
     parser.add_argument(

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -1,0 +1,160 @@
+"""Tests for the two new CLI arguments in the data preprocessor.
+
+``--models`` lets the user pass an ordered list of models to couple (a
+mutually-exclusive alternative to the single-model flags like ``--lstm``), and
+``--routing`` toggles routing for that custom coupling. Together they are wired
+into ``data_processing.modular_realization``: ``validate_input`` validates the
+selection up front, and the realization step calls
+``create_modular_realization`` / ``create_modular_configs`` with them.
+
+These tests are hermetic -- they exercise ``parse_arguments`` (pure argparse) and
+``validate_input`` with ``validate_models`` stubbed, so nothing touches the
+filesystem, the network, or the heavy build machinery.
+"""
+
+import argparse
+import sys
+
+import pytest
+
+import ngiab_data_cli.__main__ as cli_main
+from ngiab_data_cli.arguments import parse_arguments
+from data_processing.modular_realization import ACCEPTED_MODELS
+
+# The models --models is documented to accept, in declared order. This is the
+# CLI's public contract; test_models_choices_are_all_builder_accepted guards it
+# against the builder's ACCEPTED_MODELS.
+EXPECTED_MODELS_CHOICES = [
+    "sloth",
+    "nom",
+    "cfe",
+    "lstm",
+    "lstm_rust",
+    "dhbv2",
+    "dhbv2_daily",
+    "snow17",
+    "sac-sma",
+    "casam",
+]
+
+
+@pytest.fixture(name="parse_cli")
+def parse_cli_fixture(monkeypatch):
+    """Return a runner that parses a given argv list via ``parse_arguments``."""
+
+    def _parse(argv):
+        monkeypatch.setattr(sys, "argv", ["cli"] + argv)
+        return parse_arguments()
+
+    return _parse
+
+
+# ---------------------------------------------------------------------------
+# --models
+# ---------------------------------------------------------------------------
+class TestModelsArgument:
+    """Parsing behavior of the ``--models`` list argument."""
+
+    def test_models_parses_ordered_list(self, parse_cli):
+        """A space-separated list is captured in order (execution order matters)."""
+        args = parse_cli(["--models", "sloth", "nom", "cfe"])
+        assert args.models == ["sloth", "nom", "cfe"]
+
+    def test_models_accepts_single_model(self, parse_cli):
+        """nargs='+' still yields a list for a single model."""
+        args = parse_cli(["--models", "cfe"])
+        assert args.models == ["cfe"]
+
+    def test_models_defaults_to_none(self, parse_cli):
+        """Omitting --models leaves it unset so the default builder path is used."""
+        args = parse_cli(["-i", "cat-5173"])
+        assert args.models is None
+
+    def test_all_documented_choices_parse(self, parse_cli):
+        """Every advertised choice is accepted (passed together in one list)."""
+        args = parse_cli(["--models", *EXPECTED_MODELS_CHOICES])
+        assert args.models == EXPECTED_MODELS_CHOICES
+
+    def test_models_rejects_unknown_model(self, parse_cli):
+        """An out-of-choices value is rejected by argparse (exits non-zero)."""
+        with pytest.raises(SystemExit):
+            parse_cli(["--models", "not_a_model"])
+
+    def test_models_choices_are_all_builder_accepted(self):
+        """Every model the CLI offers must be one modular_realization accepts, so
+        the CLI can never hand validate_models an unbuildable name."""
+        assert set(EXPECTED_MODELS_CHOICES) <= set(ACCEPTED_MODELS)
+
+    def test_models_conflicts_with_single_model_flag(self, parse_cli):
+        """--models shares a mutually-exclusive group with the single-model flags,
+        so combining it with e.g. --lstm is a parse error."""
+        with pytest.raises(SystemExit):
+            parse_cli(["--models", "cfe", "--lstm"])
+
+
+# ---------------------------------------------------------------------------
+# --routing
+# ---------------------------------------------------------------------------
+class TestRoutingArgument:
+    """Parsing behavior of the ``--routing`` flag."""
+
+    def test_routing_defaults_to_false(self, parse_cli):
+        """Routing is off unless explicitly requested."""
+        args = parse_cli(["--models", "cfe"])
+        assert args.routing is False
+
+    def test_routing_flag_enables_it(self, parse_cli):
+        """--routing is a store_true toggle."""
+        args = parse_cli(["--routing"])
+        assert args.routing is True
+
+    def test_routing_combines_with_models(self, parse_cli):
+        """--routing is not part of the model group, so it pairs with --models."""
+        args = parse_cli(["--models", "sloth", "nom", "cfe", "--routing"])
+        assert args.models == ["sloth", "nom", "cfe"]
+        assert args.routing is True
+
+
+# ---------------------------------------------------------------------------
+# wiring: validate_input -> validate_models
+# ---------------------------------------------------------------------------
+def _args(**overrides):
+    """Build a minimal Namespace that reaches (and returns after) the --models
+    validation branch of validate_input via the early vpu return."""
+    base = {
+        "models": None,
+        "routing": False,
+        "vpu": "01",
+        "output_name": "test-out",
+        "input_feature": None,
+        "gage": False,
+        "latlon": False,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+@pytest.fixture(name="spy_validate_models")
+def spy_validate_models_fixture(monkeypatch):
+    """Record calls to validate_models without running the real validation."""
+    calls = []
+    monkeypatch.setattr(
+        cli_main, "validate_models", lambda models, routing: calls.append((models, routing))
+    )
+    return calls
+
+
+class TestValidateInputModelsWiring:
+    """validate_input must forward the model selection to validate_models."""
+
+    def test_validate_input_validates_models_with_routing(self, spy_validate_models):
+        """When --models is given, validate_input calls validate_models with the
+        exact model list and the routing flag."""
+        cli_main.validate_input(_args(models=["sloth", "cfe"], routing=True))
+        assert spy_validate_models == [(["sloth", "cfe"], True)]
+
+    def test_validate_input_skips_validation_without_models(self, spy_validate_models):
+        """No --models means the modular path is not engaged, so validate_models
+        is never called."""
+        cli_main.validate_input(_args(models=None))
+        assert spy_validate_models == []


### PR DESCRIPTION
# Title
CLI implementation for custom model couplings

## Bug Fixed / Feature Added
Added two CLI arguments `--models list of models` and `--routing`
When these flags are present, the `validate_models`, `create_modular_realization`, and `create_modular_config` methods in `modular_realization.py` are called.

## Testing / Screenshots
pytests added
Additionally, here are some commands (non-exhaustive list of combinations) you can run to test the preprocessed data in NGIAB:

`uv run cli -i cat-1555522 -sfr --start 2020-01-01 --end 2020-01-02 --source aorc --models sloth nom cfe --routing --run`
`uv run cli -i cat-1555522 -sfr --start 2020-01-01 --end 2020-01-02 --source aorc --models sloth nom casam --routing --run`
`uv run cli -i cat-1555522 -sfr --start 2020-01-01 --end 2020-01-02 --source aorc --models dhbv2 --routing --run`
`uv run cli -i cat-1555522 -sfr --start 2020-01-01 --end 2020-01-02 --source aorc --models lstm --routing --run`
`uv run cli -i cat-1555522 -sfr --start 2020-01-01 --end 2020-01-02 --source aorc --models lstm_rust --routing --run`
`uv run cli -i cat-1555522 -sfr --start 2020-01-01 --end 2020-01-02 --source aorc --models nom --run`

