### PR TITLE
fix bug where ngen fails when sloth's model_params is an empty dict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, modular-configs, casam]
+    branches: [main, modular-configs, casam, other-realizations]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/modules/data_processing/modular_realization.py
+++ b/modules/data_processing/modular_realization.py
@@ -470,7 +470,7 @@ def _insert_sloth_module(
     modules.insert(sloth_position, sloth_realization)
 
 
-def create_modular_realization( # pylint: disable=too-many-locals
+def create_modular_realization(  # pylint: disable=too-many-locals
     output_folder: str,
     start_time: datetime,
     end_time: datetime,

--- a/modules/data_processing/modular_realization.py
+++ b/modules/data_processing/modular_realization.py
@@ -462,6 +462,10 @@ def _insert_sloth_module(
     sloth_position = models.index("sloth")
     with open(MODEL_PATHS["sloth"], "r", encoding="utf-8") as f:
         sloth_realization = json.load(f)
+
+    # insert dummy param if no other params are present, otherwise BMI will throw an error
+    if not params:
+        params["sloth_dummy_param(1,double,1,node)"] = 0.0
     sloth_realization["params"]["model_params"] = params
     modules.insert(sloth_position, sloth_realization)
 

--- a/tests/test_modular_realization.py
+++ b/tests/test_modular_realization.py
@@ -292,6 +292,12 @@ class TestInsertSlothModule:
         }
         assert all(v == 0.0 for v in params.values())
 
+    def test_non_sloth_vars_are_ignored(self):
+        """Ensure non-SLOTH variables do not contribute model parameters."""
+        modules = []
+        _insert_sloth_module(["sloth"], {"cfe": {"precip": "APCP_surface"}}, modules)
+        assert modules[0]["params"]["model_params"] == {"sloth_dummy_param(1,double,1,node)": 0.0}
+
     def test_sloth_dummy_variable_added(self):
         """Ensure SLoTH dummy variable is added when no other parameters are present."""
         modules = []

--- a/tests/test_modular_realization.py
+++ b/tests/test_modular_realization.py
@@ -296,7 +296,7 @@ class TestInsertSlothModule:
         """Ensure SLoTH dummy variable is added when no other parameters are present."""
         modules = []
         _insert_sloth_module(["sloth"], {}, modules)
-        assert modules[0]["params"]["model_params"] == {'sloth_dummy_param(1,double,1,node)': 0.0}
+        assert modules[0]["params"]["model_params"] == {"sloth_dummy_param(1,double,1,node)": 0.0}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_modular_realization.py
+++ b/tests/test_modular_realization.py
@@ -292,11 +292,11 @@ class TestInsertSlothModule:
         }
         assert all(v == 0.0 for v in params.values())
 
-    def test_non_sloth_vars_are_ignored(self):
-        """Ensure non-SLOTH variables do not contribute model parameters."""
+    def test_sloth_dummy_variable_added(self):
+        """Ensure SLoTH dummy variable is added when no other parameters are present."""
         modules = []
-        _insert_sloth_module(["sloth"], {"cfe": {"precip": "APCP_surface"}}, modules)
-        assert modules[0]["params"]["model_params"] == {}
+        _insert_sloth_module(["sloth"], {}, modules)
+        assert modules[0]["params"]["model_params"] == {'sloth_dummy_param(1,double,1,node)': 0.0}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Title
fix bug where ngen fails when sloth's model_params is an empty dict

## Bug Fixed / Feature Added
ngen fails when sloth's model_params is an empty dict

## How it was fixed / implemented
Added a dummy parameter

## Testing / Screenshots
updated pytest

## Note
This is the last PR of three stacked PRs. This PR depends on PRs #237 and #238 