### PR TITLE
CLI interface for custom model couplings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,33 +10,38 @@ This repository contains tools for preparing data to run a [NextGen](https://git
 
 ## Table of Contents
 
-1. [What does this tool do?](#what-does-this-tool-do)
-2. [Limitations](#limitations)
-   - [Custom realizations](#custom-realizations)
-   - [Calibration](#calibration)
-   - [Evaluation](#evaluation)
-   - [Visualisation](#visualisation)
-3. [Requirements](#requirements)
-4. [Installation and running](#installation-and-running)
-   - [Running without install](#running-without-install)
-   - [For uv installation](#for-uv-installation)
-   - [For legacy pip installation](#for-legacy-pip-installation)
-   - [Development installation](#development-installation)
-5. [Map interface documentation](#map-interface-documentation)
-   - [Running the map interface app](#running-the-map-interface-app)
-   - [Using the map interace](#using-the-map-interface)
-6. [CLI documentation](#cli-documentation)
-   - [Running the CLI](#running-the-cli)
-   - [Arguments](#arguments)
-   - [Usage notes](#usage-notes)
-   - [Examples](#examples)
-7. [Realization information](#realization-information)
-   - [NOAH + CFE](#noah--cfe-default)
-   - [LSTM (Python)](#lstm-python)
-   - [LSTM (Rust)](#lstm-rust)
-   - [dHBV2.0 (hourly)](#dhbv20-hourly-mts)
-   - [dHBV2.0 (daily)](#dhbv20-daily)
-   - [SUMMA](#summa)
+- [NGIAB Data Preprocess](#ngiab-data-preprocess)
+  - [Table of Contents](#table-of-contents)
+  - [What does this tool do?](#what-does-this-tool-do)
+  - [Limitations](#limitations)
+    - [Calibration](#calibration)
+    - [Evaluation](#evaluation)
+    - [Visualisation](#visualisation)
+- [Requirements](#requirements)
+- [Installation and running](#installation-and-running)
+    - [Running without install](#running-without-install)
+    - [For uv installation](#for-uv-installation)
+    - [For legacy pip installation](#for-legacy-pip-installation)
+    - [Development installation](#development-installation)
+- [Map interface documentation](#map-interface-documentation)
+  - [Running the map interface app](#running-the-map-interface-app)
+  - [Using the map interface](#using-the-map-interface)
+- [CLI documentation](#cli-documentation)
+  - [Running the CLI](#running-the-cli)
+  - [Arguments](#arguments)
+  - [Usage notes](#usage-notes)
+  - [Examples](#examples)
+- [Realization information](#realization-information)
+  - [Defaults](#defaults)
+    - [NOAH + CFE (Default)](#noah--cfe-default)
+    - [LSTM (Python)](#lstm-python)
+    - [LSTM (Rust)](#lstm-rust)
+    - [dHBV2.0 (Hourly MTS)](#dhbv20-hourly-mts)
+    - [dHBV2.0 (Daily)](#dhbv20-daily)
+    - [SUMMA](#summa)
+    - [SNOW17](#snow17)
+    - [SAC-SMA](#sac-sma)
+  - [Custom](#custom)
 
 ## What does this tool do?
 
@@ -54,9 +59,6 @@ The raw forcing data is [nwm retrospective v3 forcing](https://noaa-nwm-retrospe
 
 ## Limitations
 This tool cannot do the following:
-
-### Custom realizations
-This tool currently only outputs a single, default realization, which is described in "[Realization information](#realization-information)". Support for additional model configurations is planned, but not currently available.
 
 ### Calibration
 If available, this repository will download [calibrated parameters](https://communityhydrofabric.s3.us-east-1.amazonaws.com/index.html#hydrofabrics/community/gage_parameters/) from the [Community Hydrofabric](https://github.com/CIROH-UA/community_hf_patcher) AWS S3 bucket.
@@ -206,13 +208,15 @@ Installed with uv: `uv run cli`
 - `--subset_type`: Specify the subset type. `nexus`: get everything flowing into the downstream nexus of the selected catchment. `catchment`: get everything flowing into the selected catchment.
 - `-f`, `--forcings`: Generate forcings for the given feature.
 - `-r`, `--realization`: Create a realization for the given feature.
-- `--lstm`: Configures the data for the [python lstm](https://github.com/ciroh-ua/lstm/).
-- `--lstm_rust`: Configures the data for the [rust lstm](https://github.com/ciroh-ua/rust-lstm-1025/).
-- `--dhbv2`: Configures the data for the hourly [dHBV2](https://github.com/mhpi/dhbv2).
-- `--dhbv2_daily`: Configures the data for the daily [dHBV2](https://github.com/mhpi/dhbv2).
-- `--summa`: Configures the data for the [SUMMA](https://github.com/CH-Earth/summa) model.
-- `--snow17`: Configures the data for the [SNOW17](https://github.com/NOAA-OWP/snow17) model.
-- `--sacsma`: Configures the data for the [SAC-SMA](https://github.com/NOAA-OWP/sac-sma) model.
+- `--lstm`: Configures the data for the [python lstm](https://github.com/ciroh-ua/lstm/) with t-route activated.
+- `--lstm_rust`: Configures the data for the [rust lstm](https://github.com/ciroh-ua/rust-lstm-1025/) with t-route activated.
+- `--dhbv2`: Configures the data for the hourly [dHBV2](https://github.com/mhpi/dhbv2) with t-route activated.
+- `--dhbv2_daily`: Configures the data for the daily [dHBV2](https://github.com/mhpi/dhbv2) with t-route activated.
+- `--summa`: Configures the data for the [SUMMA](https://github.com/CH-Earth/summa) model with t-route activated.
+- `--snow17`: Configures the data for the [SNOW17](https://github.com/NOAA-OWP/snow17) model. This configuration contains SLoTH, SNOW17, NOM, and CFE, and activates t-route.
+- `--sacsma`: Configures the data for the [SAC-SMA](https://github.com/NOAA-OWP/sac-sma) model. This configuration contains NOM and SAC-SMA, and activates t-route
+- `--models`: Configures the data for a user-specified model coupling, e.g., `--models sloth nom cfe`
+- `--routing`: Configures the data for a t-route run. This flag only changes preprocessor behavior if used with `--models`.
 - `--start_date START_DATE`, `--start START_DATE`: Start date for forcings/realization (format YYYY-MM-DD).
 - `--end_date END_DATE`, `--end END_DATE`: End date for forcings/realization (format YYYY-MM-DD).
 - `-o OUTPUT_NAME`, `--output_name OUTPUT_NAME`: Name of the output folder.
@@ -277,28 +281,62 @@ Installed with uv: `uv run cli`
    #         you can replace --lstm with any other model, like --lstm_rust, --dhbv2, --dhbv2_daily, --summa
    ```
 
+9. Prepare everything for a custom NGIAB SLoTH + SNOW17 + CASAM + t-route run at a given gage:
+
+   ```bash
+   uvx ngiab-prep -i gage-10154200 -sfr --start 2022-01-01 --end 2022-02-28 --models sloth snow17 casam --routing
+   ```
+
 # Realization information
 
-This tool currently offers three realizations.
+This tool currently offers eight default realizations, as well as the ability to create custom realizations with user-passed arguments.
 
-## NOAH + CFE (Default)
+## Defaults
+
+### NOAH + CFE (Default)
 
 [This realization](https://github.com/CIROH-UA/NGIAB_data_preprocess/blob/main/modules/data_sources/config/realization/cfe-nom.json) is intended to be roughly comparable to earlier versions of the National Water Model.
 - [NOAH-OWP-Modular](https://github.com/NOAA-OWP/NOAH-OWP-Modular): A refactoring of Noah-MP, a land-surface model. Used to model groundwater properties.
 - [Conceptual Functional Equivalent (CFE)](https://github.com/NOAA-OWP/CFE): A simplified conceptual approximation of versions 1.2, 2.0, and 2.1 of the National Water Model. Used to model precipitation and evaporation.
 - [SLoTH](https://github.com/NOAA-OWP/SLoTH): A module used to feed through unchanged values. In this default configuration, it simply forces certain soil moisture and ice fraction properties to zero.
 
-## LSTM (Python)
+### LSTM (Python)
 [This realization](https://github.com/CIROH-UA/NGIAB_data_preprocess/blob/main/modules/data_sources/config/realization/lstm-py.json) will run the [python lstm](https://github.com/ciroh-ua/lstm/). It's designed to work with ngiab using [these example weights](https://github.com/CIROH-UA/lstm/tree/example_weights/trained_neuralhydrology_models) generously contributed by [jmframe/lstm](https://github.com/jmframe/lstm)
 
-## LSTM (Rust)
+### LSTM (Rust)
 [This realization](https://github.com/CIROH-UA/NGIAB_data_preprocess/blob/main/modules/data_sources/config/realization/lstm-rs.json) will run the [rust port](https://github.com/CIROH-UA/rust-lstm-1025/tree/main) of the python lstm above. It's an experimental drop in replacement that should produce identical results with a ~2-5x speedup depending on your setup.
 
-## dHBV2.0 (Hourly MTS)
+### dHBV2.0 (Hourly MTS)
 [This realization](https://github.com/CIROH-UA/NGIAB_data_preprocess/blob/main/modules/data_sources/config/realization/dhbv2.json) will run the [multi-timescale dHBV2.0 model](https://github.com/mhpi/dhbv2/tree/39379fd435747a3f765d1a2201d613f9f0087448). Weights and model attributes developed by Penn State's MHPI group.
 
-## dHBV2.0 (Daily)
+### dHBV2.0 (Daily)
 [This realization](https://github.com/CIROH-UA/NGIAB_data_preprocess/blob/main/modules/data_sources/config/realization/dhbv2-daily.json) will run the [daily dHBV2.0 model](https://github.com/mhpi/dhbv2/tree/39379fd435747a3f765d1a2201d613f9f0087448). Weights and model attributes developed by Penn State's MHPI group.
 
-## SUMMA
+### SUMMA
 [This realization](https://github.com/CIROH-UA/NGIAB_data_preprocess/blob/main/modules/data_sources/config/realization/summa.json) will run the [SUMMA](https://github.com/CIROH-UA/ngen/tree/ngiab/extern/summa) model (version linked is what's currently in nextgen in a box).
+
+### SNOW17
+
+[This realization](https://github.com/CIROH-UA/NGIAB_data_preprocess/blob/main/modules/data_sources/config/realization/snow17-nom-cfe.json) will run the [SNOW17](https://github.com/CIROH-UA/ngen/tree/ngiab/extern/snow17) model in conjunction with SLoTH, Noah-OWP-Modular, CFE, and t-route.
+
+### SAC-SMA
+
+[This realization](https://github.com/CIROH-UA/NGIAB_data_preprocess/blob/main/modules/data_sources/config/realization/sacsma-nom.json) will run the [SAC-SMA](https://github.com/CIROH-UA/ngen/tree/ngiab/extern/sac-sma) model in conjunction with Noah-OWP-Modular and t-route.
+
+## Custom
+
+Users can now mix and match models to create custom realizations. Models supported by this capability are `sloth`, `nom`, `cfe`, `lstm`, `lstm_rust`, `dhbv2`, `dhbv2_daily`, `snow17`, `sac-sma`, and `casam`. SUMMA is not currently supported by this functionality, but we plan on adding it in the future. This feature includes automated validation (i.e., a warning will appear if the preprocessor thinks a user has submitted an invalid list of models to couple).
+
+To use this functionality, add the `--models` flag with the list of models you would like to couple together in the order that they should be run. To activate routing through t-route, append the `--routing` flag. Some examples include:
+
+- `uv run cli -i cat-1555522 -sfr --start 2020-01-01 --end 2020-01-02 --source aorc --models sloth nom cfe --routing --run` (Run SLoTH, Noah-OWP-Modular, CFE, and t-route)
+- `uv run cli -i cat-1555522 -sfr --start 2020-01-01 --end 2020-01-02 --source aorc --models sloth nom casam --routing --run` (Run SLotH, Noah-OWP-Modular, CASAM, and t-route)
+- `uv run cli -i cat-1555522 -sfr --start 2020-01-01 --end 2020-01-02 --source aorc --models dhbv2 --routing --run` (Run dHBV2 and t-route)
+- `uv run cli -i cat-1555522 -sfr --start 2020-01-01 --end 2020-01-02 --source aorc --models lstm --routing --run` (Run LSTM and t-route)
+- `uv run cli -i cat-1555522 -sfr --start 2020-01-01 --end 2020-01-02 --source aorc --models lstm_rust --routing --run` (Run Rust LSTM and t-route)
+- `uv run cli -i cat-1555522 -sfr --start 2020-01-01 --end 2020-01-02 --source aorc --models nom --run` (Run Noah-OWP-Modular standalone)
+- `uv run cli -i cat-1555522 -sfr --start 2020-01-01 --end 2020-01-02 --source aorc --models nom snow17 sac-sma --routing --run` (Run Noah-OWP-Modular, SNOW17, SAC-SMA, and t-route)
+- `uv run cli -i cat-1555522 -sfr --start 2020-01-01 --end 2020-01-02 --source aorc --models sloth snow17 casam --routing --run` (Run SLoTH, SNOW17, CASAM, and t-route)
+- `uv run cli -i cat-1555522 -sfr --start 2020-01-01 --end 2020-01-02 --source aorc --models snow17 --run` (Run SNOW17 standalone)
+
+Please note: the `--models` flag cannot be used in conjunction with any of the default options listed above. In addition, the presence or absence of the `--routing` flag will not change any of the default realizations' inclusion of t-route (i.e., `--routing` only has an effect when used with `--models`).

--- a/modules/data_processing/modular_realization.py
+++ b/modules/data_processing/modular_realization.py
@@ -470,7 +470,7 @@ def _insert_sloth_module(
     modules.insert(sloth_position, sloth_realization)
 
 
-def create_modular_realization(  # pylint: disable=too-many-locals
+def create_modular_realization( # pylint: disable=too-many-locals
     output_folder: str,
     start_time: datetime,
     end_time: datetime,

--- a/modules/data_processing/modular_realization.py
+++ b/modules/data_processing/modular_realization.py
@@ -3,7 +3,6 @@
 import copy
 import json
 from datetime import datetime
-import subprocess
 from rich.prompt import Prompt
 
 from data_processing.file_paths import FilePaths

--- a/modules/data_processing/modular_realization.py
+++ b/modules/data_processing/modular_realization.py
@@ -603,3 +603,5 @@ def create_modular_configs(  # pylint: disable=too-many-arguments, too-many-bran
 
     if routing:
         configure_troute(output_folder, paths.config_dir, start_time, end_time)
+
+    paths.setup_run_folders()  # creates config, output, and log folders if they don't exist

--- a/modules/ngiab_data_cli/__main__.py
+++ b/modules/ngiab_data_cli/__main__.py
@@ -28,6 +28,11 @@ with rich.status.Status("loading") as status:
     from data_processing.forcings import create_forcings
     from data_processing.gpkg_utils import get_cat_from_gage_id, get_catid_from_point
     from data_processing.graph_utils import get_upstream_cats
+    from data_processing.modular_realization import (
+        validate_models,
+        create_modular_realization,
+        create_modular_configs
+    )
     from data_processing.subset import subset, subset_vpu
     from data_sources.source_validation import validate_hydrofabric, validate_output_dir
     from ngiab_data_cli.arguments import parse_arguments
@@ -39,6 +44,9 @@ def validate_input(args: argparse.Namespace) -> Tuple[str, str]:
 
     feature_name = None
     output_folder = None
+
+    if args.models:
+        validate_models(args.models, args.routing)
 
     if args.vpu:
         if not args.output_name:
@@ -256,6 +264,21 @@ def main() -> None:
                     start_time=args.start_date,
                     end_time=args.end_date,
                     gage_id=gage_id,
+                )
+            elif args.models:
+                create_modular_realization(
+                    output_folder,
+                    start_time=args.start_date,
+                    end_time=args.end_date,
+                    models=args.models,
+                    routing=args.routing,
+                )
+                create_modular_configs(
+                    output_folder,
+                    start_time=args.start_date,
+                    end_time=args.end_date,
+                    models=args.models,
+                    routing=args.routing,
                 )
             else:
                 create_realization(

--- a/modules/ngiab_data_cli/arguments.py
+++ b/modules/ngiab_data_cli/arguments.py
@@ -121,6 +121,8 @@ def parse_arguments() -> argparse.Namespace:
         action="store_true",
         help="enable debug logging",
     )
+
+    # model flags, mutually exclusive
     models = parser.add_mutually_exclusive_group(required=False)
 
     models.add_argument(
@@ -157,6 +159,32 @@ def parse_arguments() -> argparse.Namespace:
         "--sacsma",
         action="store_true",
         help="enable SAC-SMA model realization and forcings",
+    )
+
+    # user can pass list of models to run to create custom coupling
+    models.add_argument(
+        "--models",
+        type=str,
+        nargs="+",
+        help="List of models to couple together in the order of executionß, e.g. --models sloth nom cfe",
+        choices=[
+            "sloth",
+            "nom",
+            "cfe",
+            "lstm",
+            "lstm_rust",
+            "dhbv2",
+            "dhbv2_daily",
+            "snow17",
+            "sac-sma",
+            "casam",
+        ],
+    )
+
+    parser.add_argument(
+        "--routing",
+        action="store_true",
+        help="enable routing when running with custom coupled models",
     )
 
     parser.add_argument(

--- a/modules/ngiab_data_cli/arguments.py
+++ b/modules/ngiab_data_cli/arguments.py
@@ -166,7 +166,7 @@ def parse_arguments() -> argparse.Namespace:
         "--models",
         type=str,
         nargs="+",
-        help="List of models to couple together in the order of executionß, e.g. --models sloth nom cfe",
+        help="List of models to couple together in the order of execution, e.g. --models sloth nom cfe",
         choices=[
             "sloth",
             "nom",
@@ -184,7 +184,7 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--routing",
         action="store_true",
-        help="enable routing when running with custom coupled models",
+        help="enable routing when running with custom coupled models. Note this this will not activate without --models",
     )
 
     parser.add_argument(

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -1,0 +1,160 @@
+"""Tests for the two new CLI arguments in the data preprocessor.
+
+``--models`` lets the user pass an ordered list of models to couple (a
+mutually-exclusive alternative to the single-model flags like ``--lstm``), and
+``--routing`` toggles routing for that custom coupling. Together they are wired
+into ``data_processing.modular_realization``: ``validate_input`` validates the
+selection up front, and the realization step calls
+``create_modular_realization`` / ``create_modular_configs`` with them.
+
+These tests are hermetic -- they exercise ``parse_arguments`` (pure argparse) and
+``validate_input`` with ``validate_models`` stubbed, so nothing touches the
+filesystem, the network, or the heavy build machinery.
+"""
+
+import argparse
+import sys
+
+import pytest
+
+import ngiab_data_cli.__main__ as cli_main
+from ngiab_data_cli.arguments import parse_arguments
+from data_processing.modular_realization import ACCEPTED_MODELS
+
+# The models --models is documented to accept, in declared order. This is the
+# CLI's public contract; test_models_choices_are_all_builder_accepted guards it
+# against the builder's ACCEPTED_MODELS.
+EXPECTED_MODELS_CHOICES = [
+    "sloth",
+    "nom",
+    "cfe",
+    "lstm",
+    "lstm_rust",
+    "dhbv2",
+    "dhbv2_daily",
+    "snow17",
+    "sac-sma",
+    "casam",
+]
+
+
+@pytest.fixture(name="parse_cli")
+def parse_cli_fixture(monkeypatch):
+    """Return a runner that parses a given argv list via ``parse_arguments``."""
+
+    def _parse(argv):
+        monkeypatch.setattr(sys, "argv", ["cli"] + argv)
+        return parse_arguments()
+
+    return _parse
+
+
+# ---------------------------------------------------------------------------
+# --models
+# ---------------------------------------------------------------------------
+class TestModelsArgument:
+    """Parsing behavior of the ``--models`` list argument."""
+
+    def test_models_parses_ordered_list(self, parse_cli):
+        """A space-separated list is captured in order (execution order matters)."""
+        args = parse_cli(["--models", "sloth", "nom", "cfe"])
+        assert args.models == ["sloth", "nom", "cfe"]
+
+    def test_models_accepts_single_model(self, parse_cli):
+        """nargs='+' still yields a list for a single model."""
+        args = parse_cli(["--models", "cfe"])
+        assert args.models == ["cfe"]
+
+    def test_models_defaults_to_none(self, parse_cli):
+        """Omitting --models leaves it unset so the default builder path is used."""
+        args = parse_cli(["-i", "cat-5173"])
+        assert args.models is None
+
+    def test_all_documented_choices_parse(self, parse_cli):
+        """Every advertised choice is accepted (passed together in one list)."""
+        args = parse_cli(["--models", *EXPECTED_MODELS_CHOICES])
+        assert args.models == EXPECTED_MODELS_CHOICES
+
+    def test_models_rejects_unknown_model(self, parse_cli):
+        """An out-of-choices value is rejected by argparse (exits non-zero)."""
+        with pytest.raises(SystemExit):
+            parse_cli(["--models", "not_a_model"])
+
+    def test_models_choices_are_all_builder_accepted(self):
+        """Every model the CLI offers must be one modular_realization accepts, so
+        the CLI can never hand validate_models an unbuildable name."""
+        assert set(EXPECTED_MODELS_CHOICES) <= set(ACCEPTED_MODELS)
+
+    def test_models_conflicts_with_single_model_flag(self, parse_cli):
+        """--models shares a mutually-exclusive group with the single-model flags,
+        so combining it with e.g. --lstm is a parse error."""
+        with pytest.raises(SystemExit):
+            parse_cli(["--models", "cfe", "--lstm"])
+
+
+# ---------------------------------------------------------------------------
+# --routing
+# ---------------------------------------------------------------------------
+class TestRoutingArgument:
+    """Parsing behavior of the ``--routing`` flag."""
+
+    def test_routing_defaults_to_false(self, parse_cli):
+        """Routing is off unless explicitly requested."""
+        args = parse_cli(["--models", "cfe"])
+        assert args.routing is False
+
+    def test_routing_flag_enables_it(self, parse_cli):
+        """--routing is a store_true toggle."""
+        args = parse_cli(["--routing"])
+        assert args.routing is True
+
+    def test_routing_combines_with_models(self, parse_cli):
+        """--routing is not part of the model group, so it pairs with --models."""
+        args = parse_cli(["--models", "sloth", "nom", "cfe", "--routing"])
+        assert args.models == ["sloth", "nom", "cfe"]
+        assert args.routing is True
+
+
+# ---------------------------------------------------------------------------
+# wiring: validate_input -> validate_models
+# ---------------------------------------------------------------------------
+def _args(**overrides):
+    """Build a minimal Namespace that reaches (and returns after) the --models
+    validation branch of validate_input via the early vpu return."""
+    base = {
+        "models": None,
+        "routing": False,
+        "vpu": "01",
+        "output_name": "test-out",
+        "input_feature": None,
+        "gage": False,
+        "latlon": False,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+@pytest.fixture(name="spy_validate_models")
+def spy_validate_models_fixture(monkeypatch):
+    """Record calls to validate_models without running the real validation."""
+    calls = []
+    monkeypatch.setattr(
+        cli_main, "validate_models", lambda models, routing: calls.append((models, routing))
+    )
+    return calls
+
+
+class TestValidateInputModelsWiring:
+    """validate_input must forward the model selection to validate_models."""
+
+    def test_validate_input_validates_models_with_routing(self, spy_validate_models):
+        """When --models is given, validate_input calls validate_models with the
+        exact model list and the routing flag."""
+        cli_main.validate_input(_args(models=["sloth", "cfe"], routing=True))
+        assert spy_validate_models == [(["sloth", "cfe"], True)]
+
+    def test_validate_input_skips_validation_without_models(self, spy_validate_models):
+        """No --models means the modular path is not engaged, so validate_models
+        is never called."""
+        cli_main.validate_input(_args(models=None))
+        assert spy_validate_models == []


### PR DESCRIPTION
# Title
CLI interface for custom model couplings

## Bug Fixed / Feature Added
Added CLI arguments that will call methods from `modular_realization.py` to build user-defined realizations. Also added a pytest and README updates (not sure how the table of contents got auto-updated but that's a bulk of the diffs)

## Testing / Screenshots
Pytests passed
This (non-exhaustive) list of potential commands can be run

- `uv run cli -i cat-1555522 -sfr --start 2020-01-01 --end 2020-01-02 --source aorc --models sloth nom cfe --routing --run` (Run SLoTH, Noah-OWP-Modular, CFE, and t-route)
- `uv run cli -i cat-1555522 -sfr --start 2020-01-01 --end 2020-01-02 --source aorc --models sloth nom casam --routing --run` (Run SLotH, Noah-OWP-Modular, CASAM, and t-route)
- `uv run cli -i cat-1555522 -sfr --start 2020-01-01 --end 2020-01-02 --source aorc --models dhbv2 --routing --run` (Run dHBV2 and t-route)
- `uv run cli -i cat-1555522 -sfr --start 2020-01-01 --end 2020-01-02 --source aorc --models lstm --routing --run` (Run LSTM and t-route)
- `uv run cli -i cat-1555522 -sfr --start 2020-01-01 --end 2020-01-02 --source aorc --models lstm_rust --routing --run` (Run Rust LSTM and t-route)
- `uv run cli -i cat-1555522 -sfr --start 2020-01-01 --end 2020-01-02 --source aorc --models nom --run` (Run Noah-OWP-Modular standalone)
- `uv run cli -i cat-1555522 -sfr --start 2020-01-01 --end 2020-01-02 --source aorc --models nom snow17 sac-sma --routing --run` (Run Noah-OWP-Modular, SNOW17, SAC-SMA, and t-route)
- `uv run cli -i cat-1555522 -sfr --start 2020-01-01 --end 2020-01-02 --source aorc --models sloth snow17 casam --routing --run` (Run SLoTH, SNOW17, CASAM, and t-route)
- `uv run cli -i cat-1555522 -sfr --start 2020-01-01 --end 2020-01-02 --source aorc --models snow17 --run` (Run SNOW17 standalone)
