### PR TITLE
Fix CI workflow scaffolding left in modular-configs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, modular-configs, summa-addition]
+    branches: [main]
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -40,7 +40,6 @@ jobs:
   test:
     name: pytest (unit · hermetic)
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Revert `on.pull_request.branches` from `[main, modular-configs, summa-addition]` back to `[main]` — CI should only gate PRs into `main`, not PRs targeting the in-progress feature branches directly.
- Remove `continue-on-error: true` from the `test` job (pytest unit · hermetic). It was silently defeating the purpose of the new golden-test suite by letting failing unit tests pass CI.
- Left the `integration` job's `continue-on-error: true` untouched — that one is pre-existing on `main` and intentional (integration tests hit live S3/AORC data and can be flaky).

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — no error
- [x] `uv run pytest -m "not integration"` — 59 passed
- [x] Diffed `.github/workflows/ci.yml` against `main` — file is now byte-identical to `main`'s version, confirming only the two scaffolding changes were reverted and nothing else drifted