### PR TITLE
Fix default realization path to write BMI configs and always route

### DIFF
--- a/modules/map_app/views.py
+++ b/modules/map_app/views.py
@@ -2,16 +2,16 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
-import os
 import threading
 
 import geopandas as gpd
+from data_processing.create_configs import create_modular_configs
 from data_processing.create_realization import create_modular_realization
 from data_processing.dataset_utils import save_and_clip_dataset
 from data_processing.datasets import load_aorc_zarr, load_v3_retrospective_zarr
 from data_processing.file_paths import FilePaths
 from data_processing.forcings import create_forcings
-from data_processing.graph_utils import get_upstream_cats, get_upstream_ids
+from data_processing.graph_utils import get_upstream_ids
 from data_processing.subset import subset
 from flask import Blueprint, jsonify, render_template, request
 
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 @main.route("/")
 def index():
     return render_template("index.html")
+
 
 # this subset does not include the downstream nexus
 @main.route("/get_upstream_catids", methods=["POST"])
@@ -39,6 +40,7 @@ def get_upstream_catids():
     if cat_id in cleaned_upstreams:
         cleaned_upstreams.remove(cat_id)
     return list(cleaned_upstreams), 200
+
 
 # this subset includes the downstream nexus
 @main.route("/get_upstream_wbids", methods=["POST"])
@@ -65,12 +67,12 @@ def subset_check():
     if run_paths.geopackage_path.exists():
         return str(run_paths.geopackage_path), 409
     else:
-        return "no conflict",200
+        return "no conflict", 200
 
 
 @main.route("/subset", methods=["POST"])
 def subset_selection():
-    #body: JSON.stringify({ 'cat_id': [cat_id], 'subset_type': subset_type})
+    # body: JSON.stringify({ 'cat_id': [cat_id], 'subset_type': subset_type})
     data = json.loads(request.data.decode("utf-8"))
     cat_ids = data.get("cat_id")
     subset_type = data.get("subset_type")
@@ -82,7 +84,12 @@ def subset_selection():
     if subset_type == "nexus":
         subset(cat_ids, output_gpkg_path=run_paths.geopackage_path, override_gpkg=True)
     else:
-        subset(cat_ids, output_gpkg_path=run_paths.geopackage_path, include_outlet=False, override_gpkg=True)
+        subset(
+            cat_ids,
+            output_gpkg_path=run_paths.geopackage_path,
+            include_outlet=False,
+            override_gpkg=True,
+        )
     return str(run_paths.geopackage_path), 200
 
 
@@ -100,6 +107,7 @@ def subset_to_file():
         f.write("\n".join(total_subset))
     return str(subset_paths.subset_dir), 200
 
+
 @main.route("/make_forcings_progress_file", methods=["POST"])
 def make_forcings_progress_file():
     data = json.loads(request.data.decode("utf-8"))
@@ -110,18 +118,20 @@ def make_forcings_progress_file():
         json.dump({"total_steps": 0, "steps_completed": 0}, f)
     return str(paths.forcing_progress_file), 200
 
+
 @main.route("/forcings_progress", methods=["POST"])
 def forcings_progress_endpoint():
     progress_file = Path(json.loads(request.data.decode("utf-8")))
     with open(progress_file, "r") as f:
         forcings_progress = json.load(f)
-    forcings_progress_all = forcings_progress['total_steps']
-    forcings_progress_completed = forcings_progress['steps_completed']
+    forcings_progress_all = forcings_progress["total_steps"]
+    forcings_progress_completed = forcings_progress["steps_completed"]
     try:
         percent = int((forcings_progress_completed / forcings_progress_all) * 100)
     except ZeroDivisionError:
         percent = "NaN"
     return str(percent), 200
+
 
 def download_forcings(data_source, start_time, end_time, paths):
     if data_source == "aorc":
@@ -134,8 +144,10 @@ def download_forcings(data_source, start_time, end_time, paths):
     cached_data = save_and_clip_dataset(raw_data, gdf, start_time, end_time, paths.cached_nc_file)
     return cached_data
 
+
 def compute_forcings(cached_data, paths):
     create_forcings(cached_data, paths.output_dir.stem)  # type: ignore
+
 
 @main.route("/forcings", methods=["POST"])
 def get_forcings():
@@ -163,10 +175,10 @@ def get_forcings():
 
     cached_data = download_forcings(data_source, start_time, end_time, paths)
     # threading implemented so that main process can periodically poll progress file
-    thread = threading.Thread(target=compute_forcings,
-                              args=(cached_data, paths))
+    thread = threading.Thread(target=compute_forcings, args=(cached_data, paths))
     thread.start()
     return "started", 200
+
 
 @main.route("/realization", methods=["POST"])
 def get_realization():
@@ -180,11 +192,15 @@ def get_realization():
     start_time = datetime.strptime(start_time, "%Y-%m-%dT%H:%M")
     end_time = datetime.strptime(end_time, "%Y-%m-%dT%H:%M")
     create_modular_realization(
+        output_folder, start_time, end_time, ["sloth", "nom", "cfe"], routing=True
+    )
+    create_modular_configs(
         output_folder,
-        start_time,
-        end_time,
-        ["sloth", "nom", "cfe"],
-        routing=True)
+        start_time=start_time,
+        end_time=end_time,
+        models=["sloth", "nom", "cfe"],
+        routing=True,
+    )
     return "success", 200
 
 

--- a/modules/ngiab_data_cli/__main__.py
+++ b/modules/ngiab_data_cli/__main__.py
@@ -45,11 +45,17 @@ def validate_input(args: argparse.Namespace) -> Tuple[str, str]:
             warning_message = "Model configuration warnings:\n" + "\n".join(warnings)
             logging.warning(warning_message)
 
-            response = Prompt.ask(
-                "Run anyway? (y/n)",
-                default="n",
-                choices=["y", "n"],
-            )
+            if sys.stdin.isatty():
+                response = Prompt.ask(
+                    "Run anyway? (y/n)",
+                    default="n",
+                    choices=["y", "n"],
+                )
+            else:
+                logging.warning(
+                    "Non-interactive session detected, proceeding automatically despite warnings."
+                )
+                response = "y"
             if response == "n":
                 raise ValueError("Model configuration invalid: " + warning_message)
             print("Proceeding with data preprocessing despite warnings: " + warning_message)
@@ -244,7 +250,7 @@ def main() -> None:
                     end_time=args.end_date,
                     models=args.models,
                     routing=args.routing,
-                    gage_id=gage_id
+                    gage_id=gage_id,
                 )
                 create_modular_configs(
                     output_folder,
@@ -255,13 +261,21 @@ def main() -> None:
                 )
             else:
                 # default to SLoTH + NOM + CFE + t-route
+                # default realizations always include t-route regardless of --routing
                 create_modular_realization(
                     output_folder,
                     start_time=args.start_date,
                     end_time=args.end_date,
                     models=["sloth", "nom", "cfe"],
-                    routing=args.routing,
-                    gage_id=gage_id
+                    routing=True,
+                    gage_id=gage_id,
+                )
+                create_modular_configs(
+                    output_folder,
+                    start_time=args.start_date,
+                    end_time=args.end_date,
+                    models=["sloth", "nom", "cfe"],
+                    routing=True,
                 )
             logging.info("Realization creation complete.")
 
@@ -270,20 +284,20 @@ def main() -> None:
 
             try:
                 subprocess.run("docker pull awiciroh/ciroh-ngen-image:latest", shell=True)
-            except:
+            except Exception:
                 logging.error("Docker is not running, please start Docker and try again.")
             try:
                 command = f'docker run --rm -it -v "{str(paths.subset_dir)}:/ngen/ngen/data" awiciroh/ciroh-ngen-image:latest /ngen/ngen/data/ auto {cpu_count()} local'
                 subprocess.run(command, shell=True)
                 logging.info("Next Gen run complete.")
-            except:
+            except Exception:
                 logging.error("Next Gen run failed.")
 
         if args.eval:
             plot = False
             try:
-                import matplotlib
-                import seaborn
+                import matplotlib  # noqa: F401
+                import seaborn  # noqa: F401
 
                 plot = True
             except ImportError:
@@ -307,7 +321,7 @@ def main() -> None:
             try:
                 command = f'docker run --rm -it -p 3000:3000 -v "{str(paths.subset_dir)}:/ngen/ngen/data/" joshcu/ngiab_grafana:v0.2.1'
                 subprocess.run(command, shell=True)
-            except:
+            except Exception:
                 logging.error("Failed to launch docker container.")
 
         logging.info("All operations completed successfully.")

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -35,7 +35,7 @@ EXPECTED_MODELS_CHOICES = [
     "snow17",
     "sac-sma",
     "casam",
-    "summa"
+    "summa",
 ]
 
 
@@ -153,3 +153,32 @@ class TestValidateInputModelsWiring:
         is never called."""
         cli_main.validate_input(_args(models=None))
         assert spy_validate_models == []
+
+
+# ---------------------------------------------------------------------------
+# validate_input: non-interactive stdin must not block on Prompt.ask
+# ---------------------------------------------------------------------------
+class _NonTtyStdin:
+    """Minimal stand-in for sys.stdin that reports itself as not a TTY."""
+
+    def isatty(self):
+        return False
+
+
+class TestValidateInputNonInteractive:
+    """When stdin is not a TTY (piped input, cron, CI), validate_input must not
+    call Prompt.ask -- doing so would hang or raise in a non-interactive
+    session. Instead it should log and proceed as if the user answered "y"."""
+
+    def test_skips_prompt_and_proceeds_when_not_a_tty(self, monkeypatch):
+        monkeypatch.setattr(cli_main, "validate_models", lambda models, routing: ["some warning"])
+        monkeypatch.setattr(sys, "stdin", _NonTtyStdin())
+
+        def _fail_if_called(*args, **kwargs):
+            raise AssertionError("Prompt.ask must not be called when stdin is not a TTY")
+
+        monkeypatch.setattr(cli_main.Prompt, "ask", _fail_if_called)
+
+        # Should not raise: warnings are present, but the non-interactive
+        # fallback treats the response as "y" (proceed), not "n".
+        cli_main.validate_input(_args(models=["sloth", "cfe"], routing=True))


### PR DESCRIPTION
## Summary

`/review 245` found that the default (no `--models`) realization path in both the CLI and the map-app's `/realization` endpoint calls `create_modular_realization()` to write `realization.json`, but never calls the sibling `create_modular_configs()` that writes the BMI config files (`cat_config/CFE/*.ini`, `cat_config/NOAH-OWP-M/*.input`) and `troute.yaml` that `realization.json` references. Result: the most common CLI invocation (`cli -i cat-X -sfr`, no `--models`) produced a `realization.json` pointing at files that don't exist, and ngen would fail.

This PR fixes 3 issues:

- **`modules/ngiab_data_cli/__main__.py`** — the default (`else`) branch of the `if args.realization:` block now also calls `create_modular_configs(models=["sloth", "nom", "cfe"], routing=True)` alongside `create_modular_realization`, mirroring the `--models` branch's shape. It also now hardcodes `routing=True` for the default path (previously `routing=args.routing`, which defaults to `False`) — per the README, default realizations always include t-route regardless of `--routing`; `--routing` only affects the `--models` path.
- **`modules/map_app/views.py`** — `get_realization()` now calls `create_modular_configs` (imported from `data_processing.create_configs`) right after `create_modular_realization`, with the same models list and `routing=True`.
- **`validate_input()` in `modules/ngiab_data_cli/__main__.py`** — the `Prompt.ask("Run anyway? (y/n)", ...)` call (triggered when `validate_models()` returns warnings) now only runs when `sys.stdin.isatty()` is `True`. In a non-interactive session (piped input, cron, CI) it instead logs a warning and proceeds as if the user answered `"y"`, instead of hanging/erroring on `Prompt.ask`.

Also cleaned up pre-existing `ruff` findings (bare `except`, unused imports, formatting) in the two touched files, since CI lints the *entire* file for anything that appears in a PR's diff, not just the changed hunks.

## Test plan
- [x] Added `tests/test_cli_args.py::TestValidateInputNonInteractive::test_skips_prompt_and_proceeds_when_not_a_tty` — monkeypatches `validate_models` to return a warning and `sys.stdin` to a non-TTY stand-in, then asserts `Prompt.ask` is never invoked and `validate_input` does not raise.
- [x] Did **not** add a hermetic test asserting `main()`'s default dispatch calls both `create_modular_realization` and `create_modular_configs` with `routing=True` — `main()` is monolithic (real `FilePaths`, docker subprocess calls, forcings downloads, `set_dependent_flags` side effects all inline), so isolating just the `args.realization` branch would require excessive mocking rather than a clean unit test. The 3-line fix itself is straightforward to verify by inspection.
- [x] `uv run pytest -m "not integration"` — 60 passed.
- [x] `uvx ruff@0.11.9 check` and `uvx ruff@0.11.9 format --check` on the 3 changed files — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)