### PR TITLE
Fix t-route path regression for nested output_folder names

### DIFF
--- a/modules/data_processing/create_configs.py
+++ b/modules/data_processing/create_configs.py
@@ -1,4 +1,5 @@
 """Functions to generate BMI config files."""
+
 import logging
 import multiprocessing
 import os
@@ -69,12 +70,12 @@ def _get_model_attributes(hydrofabric: Path, layer: str = "divides") -> pandas.D
     conf_df["latitude"] = lat
     return conf_df
 
+
 # CONFIG GENERATORS!!
 
+
 def _make_cfe_config(
-    divide_conf_df: pandas.DataFrame,
-    files: FilePaths,
-    water_levels: dict
+    divide_conf_df: pandas.DataFrame, files: FilePaths, water_levels: dict
 ) -> None:
     """
     Parses parameters from NOAHOWP_CFE DataFrame and returns a dictionary of catchment \
@@ -347,7 +348,7 @@ def _make_casam_config(
     divide_conf_df: pandas.DataFrame,
     start_time: datetime,
     end_time: datetime,
-    sft_coupled: bool
+    sft_coupled: bool,
 ) -> None:
     """Generates CASAM BMI config
 
@@ -389,7 +390,7 @@ def _make_casam_config(
                     field_capacity_psi=row["field_capacity_psi"],
                     giuh_ordinates=fmt_list(row["giuh_ordinates"]),
                     sft_coupled=str(sft_coupled).lower(),
-                    soil_z=fmt_list(row["soil_z"])
+                    soil_z=fmt_list(row["soil_z"]),
                 )
             )
 
@@ -400,7 +401,8 @@ def _configure_troute(
     with open(FilePaths.template_troute_config, "r") as file:
         troute_template = file.read()
     time_step_size = 300
-    gpkg_file_path = f"{config_dir}/{cat_id}_subset.gpkg"
+    output_name = Path(cat_id).name
+    gpkg_file_path = config_dir / f"{output_name}_subset.gpkg"
     nts = (end_time - start_time).total_seconds() / time_step_size
     with sqlite3.connect(gpkg_file_path) as conn:
         ncats_df = pandas.read_sql_query("SELECT COUNT(id) FROM 'divides';", conn)
@@ -428,7 +430,7 @@ def _configure_troute(
         time_step_size=time_step_size,
         # troute seems to be ok with setting this to your cpu_count
         cpu_pool=multiprocessing.cpu_count(),
-        geo_file_path=f"./config/{cat_id}_subset.gpkg",
+        geo_file_path=f"./config/{output_name}_subset.gpkg",
         start_datetime=start_time.strftime("%Y-%m-%d %H:%M:%S"),
         nts=nts,
         max_loop_size=max_loop_size,
@@ -438,7 +440,9 @@ def _configure_troute(
     with open(config_dir / "troute.yaml", "w") as file:
         file.write(filled_template)
 
+
 # SUMMA specific functions
+
 
 def _make_summa_config(hru_ids: list[int], output_dir: Path):
     with open(FilePaths.template_summa_config, "r") as file:
@@ -571,7 +575,7 @@ def _make_summa_attributes(hru_ids, hydrofabric):
     return ds
 
 
-def _make_summa_trialParams(hru_ids: list[int], timesteps: int) -> xr.Dataset: # pylint: disable=invalid-name
+def _make_summa_trialParams(hru_ids: list[int], timesteps: int) -> xr.Dataset:  # pylint: disable=invalid-name
     ds = xr.Dataset(
         {
             "hruId": xr.DataArray(
@@ -593,10 +597,10 @@ def _make_summa_trialParams(hru_ids: list[int], timesteps: int) -> xr.Dataset: #
     return ds
 
 
-def _make_summa_coldState(hru_ids): # pylint: disable=invalid-name
+def _make_summa_coldState(hru_ids):  # pylint: disable=invalid-name
     n_hru = len(hru_ids)
-    n_midToto = 3 # pylint: disable=invalid-name
-    n_ifcToto = 4 # pylint: disable=invalid-name
+    n_midToto = 3  # pylint: disable=invalid-name
+    n_ifcToto = 4  # pylint: disable=invalid-name
 
     def scalar_var(fill_val, dtype=np.float64):
         return xr.DataArray(
@@ -610,12 +614,12 @@ def _make_summa_coldState(hru_ids): # pylint: disable=invalid-name
             dims=[dim_name, "hru"],
         )
 
-    iLayerHeight_data = np.broadcast_to( # pylint: disable=invalid-name
+    iLayerHeight_data = np.broadcast_to(  # pylint: disable=invalid-name
         np.array([0.0, 0.2, 0.5, 1.0])[:, np.newaxis],
         (n_ifcToto, n_hru),
     ).copy()
 
-    mLayerDepth_data = np.broadcast_to( # pylint: disable=invalid-name
+    mLayerDepth_data = np.broadcast_to(  # pylint: disable=invalid-name
         np.array([0.2, 0.3, 0.5])[:, np.newaxis],
         (n_midToto, n_hru),
     ).copy()
@@ -663,8 +667,8 @@ def _make_summa_coldState(hru_ids): # pylint: disable=invalid-name
 
 
 def _make_summa_config_suite(cat_id: str, start_time: datetime, end_time: datetime):
-    """Makes SUMMA configuration files. Much of this code is duplicated from
-    create_summa_realization, which will be the task of a future refactor to clean up
+    """Makes SUMMA configuration files: model config, attributes, trial params, and
+    cold state, plus copies the static SUMMA file manager suite into the run directory.
 
     Args:
         cat_id (str): Catchment ID
@@ -700,6 +704,7 @@ def _make_summa_config_suite(cat_id: str, start_time: datetime, end_time: dateti
     ds.to_netcdf(paths.summa_model_config / "coldState.nc", encoding=encoding)
     _make_summa_config(hru_ids, paths.config_dir)
     paths.setup_run_folders(["outputs/summa"])
+
 
 def create_modular_configs(  # pylint: disable=too-many-branches
     output_folder: str,

--- a/tests/test_modular_config.py
+++ b/tests/test_modular_config.py
@@ -1,8 +1,8 @@
-"""Config-generation tests for ``create_configs`` (the orchestration wrapper).
-"""
+"""Config-generation tests for ``create_configs`` (the orchestration wrapper)."""
 
 import difflib
 import json
+import re
 import shutil
 from pathlib import Path
 
@@ -66,7 +66,8 @@ def _generate_modular_config(cat_id, tmp_root, monkeypatch, *, models, routing=F
         if f.is_file() and f.suffix != ".gpkg" and f.name != "realization.json":
             rel = str(f.relative_to(paths.config_dir))
             produced[rel] = normalize(
-                f.read_text(errors="replace"), paths.output_dir # type: ignore
+                f.read_text(errors="replace"),
+                paths.output_dir,  # type: ignore
             )
 
     return produced
@@ -147,6 +148,36 @@ class TestOrchestration:
             CAT_ID, tmp_path, monkeypatch, models=["cfe"], routing=True
         )
         assert "troute.yaml" in produced
+
+    def test_troute_nested_output_folder_uses_leaf_name(self, tmp_path, monkeypatch, require):
+        """A nested output_folder (containing a path separator) must not leak into
+        the on-disk gpkg lookup or the troute.yaml geo_file_path -- both must
+        resolve to the bare leaf name, matching how FilePaths.geopackage_path
+        always builds the real gpkg filename from the leaf-only folder_name.
+
+        Regression test for the path-handling bug fixed on main in #228
+        ("Fix output_name path handling"), which was silently reintroduced when
+        config generation was split out into create_configs.py.
+        """
+        require(CAT_ID)
+        monkeypatch.chdir(tmp_path)
+        nested_id = f"nested/{CAT_ID}"
+
+        # FilePaths resolves a multi-segment folder_name relative to cwd (not
+        # get_working_dir()), so chdir into tmp_path keeps this hermetic. The gpkg
+        # itself still only ever lives at paths.geopackage_path (leaf-name only).
+        paths = FilePaths(nested_id)
+        paths.config_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy(GEOPACKAGE_FIXTURES[CAT_ID], paths.geopackage_path)
+
+        create_modular_configs(nested_id, START, END, ["cfe"], routing=True)
+
+        troute_yaml = (paths.config_dir / "troute.yaml").read_text()
+        match = re.search(r"geo_file_path:\s*(\S+)", troute_yaml)
+        assert match, "troute.yaml missing geo_file_path"
+        geo_file_path = match.group(1)
+        assert geo_file_path == f"./config/{CAT_ID}_subset.gpkg"
+        assert "nested" not in geo_file_path
 
     def test_routing_false_omits_troute(self, tmp_path, monkeypatch, require):
         """routing=False must not emit a troute.yaml."""


### PR DESCRIPTION
## Summary
- `_configure_troute` in `modules/data_processing/create_configs.py` interpolated the raw `cat_id`/`output_folder` string directly into the sqlite gpkg lookup path and into `troute.yaml`'s `geo_file_path`, instead of the leaf-only name that `FilePaths.geopackage_path` always uses. Any `output_folder` containing a path separator (e.g. `-o some/nested/name`) would cause the sqlite lookup to miss the real gpkg and would bake a wrong path into `troute.yaml`.
- Restores the `Path(cat_id).name` normalization from commit `4c0a96e` (#228, "Fix output_name path handling"), which was silently reintroduced as a bug when config generation was split out of `create_realization.py` into `create_configs.py` in this PR's refactor.
- Also removes a stale docstring reference in `_make_summa_config_suite` to `create_summa_realization`, which no longer exists anywhere in the codebase.

## Test plan
- [x] Added `TestOrchestration::test_troute_nested_output_folder_uses_leaf_name` in `tests/test_modular_config.py`, driving `create_modular_configs` with a nested `output_folder` (`"nested/cat-1555522"`) and `routing=True`; asserts it doesn't raise and that `troute.yaml`'s `geo_file_path` contains only the leaf name.
- [x] Verified the new test fails (sqlite `OperationalError: no such table: divides`) against the pre-fix code, and passes after the fix.
- [x] `uv run pytest -m "not integration"` passes (59 passed).
- [x] `uv run pytest tests/test_modular_config.py -v` (without marker filter) passes all 9 tests, including the existing golden-comparison tests — output unchanged for non-nested cases.
- [x] `uvx ruff@0.11.9 check` and `format --check` pass on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)