### PR TITLE
Fix calibrated-params path not writing realization.json

### DIFF
--- a/modules/data_processing/create_realization.py
+++ b/modules/data_processing/create_realization.py
@@ -13,6 +13,7 @@ from data_processing.file_paths import FilePaths
 
 logger = logging.getLogger(__name__)
 
+
 @dataclass(frozen=True)
 class ModelSpec:
     """All per-model coupling knowledge for one model.
@@ -46,6 +47,21 @@ class ModelSpec:
 # THE REGISTRY
 # One entry per model. Order here is only for readability.
 # ---------------------------------------------------------------------------
+
+# dhbv2 and dhbv2_daily share an identical forcing variables_names_map; the registry
+# is read-only (ModelSpec is frozen) and create_modular_realization always deep-copies
+# before mutating, so both entries can safely reference this one dict.
+_DHBV2_FORCING_VARS_MAP = {
+    "atmosphere_water__liquid_equivalent_precipitation_rate": "precip_rate",
+    "land_surface_air__temperature": "TMP_2maboveground",
+    "atmosphere_air_water~vapor__relative_saturation": "SPFH_2maboveground",
+    "land_surface_radiation~incoming~longwave__energy_flux": "DLWRF_surface",
+    "land_surface_radiation~incoming~shortwave__energy_flux": "DSWRF_surface",
+    "land_surface_air__pressure": "PRES_surface",
+    "land_surface_wind__x_component_of_velocity": "UGRD_10maboveground",
+    "land_surface_wind__y_component_of_velocity": "VGRD_10maboveground",
+    "land_surface_water__runoff_volume_flux": "streamflow",
+}
 
 MODEL_REGISTRY: dict[str, ModelSpec] = {
     "sloth": ModelSpec(
@@ -139,44 +155,24 @@ MODEL_REGISTRY: dict[str, ModelSpec] = {
     "lstm": ModelSpec(
         main_output_variable="land_surface_water__runoff_depth",
         realization_fragment=FilePaths.lstm_modular_config,
-        routable=True
+        routable=True,
     ),
     "lstm_rust": ModelSpec(
         main_output_variable="land_surface_water__runoff_depth",
         realization_fragment=FilePaths.lstm_rust_modular_config,
-        routable=True
+        routable=True,
     ),
     "dhbv2": ModelSpec(
         main_output_variable="land_surface_water__runoff_volume_flux",
         realization_fragment=FilePaths.dhbv2_modular_config,
         routable=True,
-        variables_names_map={
-            "atmosphere_water__liquid_equivalent_precipitation_rate": "precip_rate",
-            "land_surface_air__temperature": "TMP_2maboveground",
-            "atmosphere_air_water~vapor__relative_saturation": "SPFH_2maboveground",
-            "land_surface_radiation~incoming~longwave__energy_flux": "DLWRF_surface",
-            "land_surface_radiation~incoming~shortwave__energy_flux": "DSWRF_surface",
-            "land_surface_air__pressure": "PRES_surface",
-            "land_surface_wind__x_component_of_velocity": "UGRD_10maboveground",
-            "land_surface_wind__y_component_of_velocity": "VGRD_10maboveground",
-            "land_surface_water__runoff_volume_flux": "streamflow",
-        },
+        variables_names_map=_DHBV2_FORCING_VARS_MAP,
     ),
     "dhbv2_daily": ModelSpec(
         main_output_variable="land_surface_water__runoff_volume_flux",
         realization_fragment=FilePaths.dhbv2_daily_modular_config,
         routable=True,
-        variables_names_map={
-            "atmosphere_water__liquid_equivalent_precipitation_rate": "precip_rate",
-            "land_surface_air__temperature": "TMP_2maboveground",
-            "atmosphere_air_water~vapor__relative_saturation": "SPFH_2maboveground",
-            "land_surface_radiation~incoming~longwave__energy_flux": "DLWRF_surface",
-            "land_surface_radiation~incoming~shortwave__energy_flux": "DSWRF_surface",
-            "land_surface_air__pressure": "PRES_surface",
-            "land_surface_wind__x_component_of_velocity": "UGRD_10maboveground",
-            "land_surface_wind__y_component_of_velocity": "VGRD_10maboveground",
-            "land_surface_water__runoff_volume_flux": "streamflow",
-        },
+        variables_names_map=_DHBV2_FORCING_VARS_MAP,
     ),
     "summa": ModelSpec(
         main_output_variable="land_surface_water__runoff_volume_flux",
@@ -308,10 +304,29 @@ ALL_SLOTH_MODEL_PARAMS = {
 # Read as: ("target_model", lambda models: <condition that means rule is broken>, "warning")
 # ---------------------------------------------------------------------------
 
+
 def _is_coupled(models: list[str]) -> bool:
     if len([m for m in models if m != "sloth"]) > 1:
         return True
     return False
+
+
+# Standalone models (LSTM variants, dHBV2 variants) should never be coupled with a
+# physics model -- shared predicate + label map avoids repeating the same lambda/tuple
+# shape for each one below.
+_PHYSICS_MODELS = ("cfe", "casam", "sft", "smp", "sac-sma", "topmodel")
+
+
+def _standalone_conflict(models: list[str]) -> bool:
+    return any(m in models for m in _PHYSICS_MODELS)
+
+
+_STANDALONE_MODEL_LABELS = {
+    "lstm": "LSTM",
+    "lstm_rust": "LSTM-rust",
+    "dhbv2": "dHBV2",
+    "dhbv2_daily": "dHBV2-daily",
+}
 
 MODEL_DEPENDENCY_RULES = (
     # SLoTH required — bootstraps defaults for any model needing inter-model vars at t=0
@@ -363,33 +378,13 @@ MODEL_DEPENDENCY_RULES = (
     #     "SFT has no downstream consumer (CFE or CASAM) and no SMP",
     # ),
     # Standalone models should not couple with physics models
-    (
-        "lstm",
-        lambda models: any(
-            m in models for m in ("cfe", "casam", "sft", "smp", "sac-sma", "topmodel")
-        ),
-        "LSTM is standalone — unexpected coupling with physics models",
-    ),
-    (
-        "lstm_rust",
-        lambda models: any(
-            m in models for m in ("cfe", "casam", "sft", "smp", "sac-sma", "topmodel")
-        ),
-        "LSTM-rust is standalone — unexpected coupling with physics models",
-    ),
-    (
-        "dhbv2",
-        lambda models: any(
-            m in models for m in ("cfe", "casam", "sft", "smp", "sac-sma", "topmodel")
-        ),
-        "dHBV2 is standalone — unexpected coupling with physics models",
-    ),
-    (
-        "dhbv2_daily",
-        lambda models: any(
-            m in models for m in ("cfe", "casam", "sft", "smp", "sac-sma", "topmodel")
-        ),
-        "dHBV2-daily is standalone — unexpected coupling with physics models",
+    *(
+        (
+            model,
+            _standalone_conflict,
+            f"{label} is standalone — unexpected coupling with physics models",
+        )
+        for model, label in _STANDALONE_MODEL_LABELS.items()
     ),
     (
         "summa",
@@ -424,8 +419,8 @@ def validate_models(models: list[str], routing: bool) -> list:
         invalid_models = [model for model in models if model not in MODEL_REGISTRY]
         raise ValueError(
             (
-                f"Invalid models specified: {invalid_models}. " +
-                f"Supported models are: {list(MODEL_REGISTRY.keys())}"
+                f"Invalid models specified: {invalid_models}. "
+                + f"Supported models are: {list(MODEL_REGISTRY.keys())}"
             )
         )
 
@@ -454,7 +449,9 @@ def _insert_sloth_module(
                 params[varname + ALL_SLOTH_MODEL_PARAMS[varname]] = 0.0
     sloth_position = models.index("sloth")
     with open(
-        MODEL_REGISTRY["sloth"].realization_fragment, "r", encoding="utf-8" # type: ignore
+        MODEL_REGISTRY["sloth"].realization_fragment,
+        "r",
+        encoding="utf-8",  # type: ignore
     ) as f:
         sloth_realization = json.load(f)
 
@@ -465,7 +462,9 @@ def _insert_sloth_module(
     modules.insert(sloth_position, sloth_realization)
 
 
-def _handle_calibrated_params(paths: FilePaths, gage_id: str) -> bool:
+def _handle_calibrated_params(
+    paths: FilePaths, gage_id: str, start_time: datetime, end_time: datetime
+) -> bool:
     # try and download s3:communityhydrofabric/hydrofabrics/community/gage_parameters/gage_id
     # if it doesn't exist, use the default
     url = (
@@ -476,9 +475,11 @@ def _handle_calibrated_params(paths: FilePaths, gage_id: str) -> bool:
 
     if response.status_code == 200:
         new_template = response.json()
-        template_path = paths.config_dir / "downloaded_params.json"
-        with open(template_path, "w", encoding="utf-8") as f:
-            json.dump(new_template, f)
+        new_template["time"]["start_time"] = datetime.strftime(start_time, "%Y-%m-%d %H:%M:%S")
+        new_template["time"]["end_time"] = datetime.strftime(end_time, "%Y-%m-%d %H:%M:%S")
+        realization_path = paths.config_dir / "realization.json"
+        with open(realization_path, "w", encoding="utf-8") as f:
+            json.dump(new_template, f, indent=4)
 
         logger.info("downloaded calibrated parameters for %s", gage_id)
         return True
@@ -516,7 +517,7 @@ def create_modular_realization(  # pylint: disable=too-many-locals,too-many-argu
 
     # calibrated parameter fetching
     if gage_id is not None and models == ["sloth", "nom", "cfe"]:
-        if _handle_calibrated_params(paths, gage_id):
+        if _handle_calibrated_params(paths, gage_id, start_time, end_time):
             return
 
     main_output_variable = MODEL_REGISTRY[models[-1]].main_output_variable
@@ -540,7 +541,9 @@ def create_modular_realization(  # pylint: disable=too-many-locals,too-many-argu
                 target_variable_names[model].update(overrides)
 
         with open(
-            MODEL_REGISTRY[model].realization_fragment, "r", encoding="utf-8" # type: ignore
+            MODEL_REGISTRY[model].realization_fragment,
+            "r",
+            encoding="utf-8",  # type: ignore
         ) as f:
             realization = json.load(f)
         if model in target_variable_names:
@@ -555,9 +558,9 @@ def create_modular_realization(  # pylint: disable=too-many-locals,too-many-argu
     with open(FilePaths.modular_template, "r", encoding="utf-8") as f:
         realization = json.load(f)
 
-    realization["global"]["formulations"][0]["params"][
-        "main_output_variable"
-    ] = main_output_variable
+    realization["global"]["formulations"][0]["params"]["main_output_variable"] = (
+        main_output_variable
+    )
     realization["global"]["formulations"][0]["params"]["modules"] = modules
     realization["time"]["start_time"] = datetime.strftime(start_time, "%Y-%m-%d %H:%M:%S")
     realization["time"]["end_time"] = datetime.strftime(end_time, "%Y-%m-%d %H:%M:%S")

--- a/tests/test_modular_realization.py
+++ b/tests/test_modular_realization.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from data_processing.file_paths import FilePaths
+from data_processing import create_realization
 from data_processing.create_realization import (
     ALL_SLOTH_MODEL_PARAMS,
     MODEL_REGISTRY,
@@ -39,12 +40,19 @@ def make_realization_fixture(tmp_path, monkeypatch):
     monkeypatch.setattr(FilePaths, "get_working_dir", classmethod(lambda cls: Path(tmp_path)))
 
     def _run(  # pylint: disable=too-many-arguments
-        models, *, folder="cat-test", start=START, end=END, routing=False, make_config=True
+        models,
+        *,
+        folder="cat-test",
+        start=START,
+        end=END,
+        routing=False,
+        make_config=True,
+        gage_id=None,
     ):
         paths = FilePaths(folder)
         if make_config:
             paths.config_dir.mkdir(parents=True, exist_ok=True)
-        create_modular_realization(folder, start, end, models, routing=routing)
+        create_modular_realization(folder, start, end, models, routing=routing, gage_id=gage_id)
         return json.loads((paths.config_dir / "realization.json").read_text())
 
     return _run
@@ -292,8 +300,9 @@ class TestCreateModularRealization:
         """cfe before nom -> cfe keeps its default (sloth/forcing) sources."""
         r = make_realization(["sloth", "cfe", "nom"])
         vmap = _cfe_module(r)["params"]["variables_names_map"]
-        assert vmap["water_potential_evaporation_flux"] == (
-            MODEL_REGISTRY["cfe"].variables_names_map["water_potential_evaporation_flux"]
+        assert (
+            vmap["water_potential_evaporation_flux"]
+            == (MODEL_REGISTRY["cfe"].variables_names_map["water_potential_evaporation_flux"])
         )
 
     def test_routing_on_adds_troute_block(self, make_realization):
@@ -319,3 +328,102 @@ class TestCreateModularRealization:
             make_realization(
                 ["sloth", "cfe"], start="2020-01-01 00:00:00", end="2020-01-02 00:00:00"
             )
+
+
+# ---------------------------------------------------------------------------
+# create_modular_realization -- calibrated-parameter (gage_id) path
+# ---------------------------------------------------------------------------
+class _FakeResponse:
+    """Minimal stand-in for a ``requests.Response``."""
+
+    def __init__(self, status_code, payload=None):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class TestCreateModularRealizationCalibratedParams:
+    """Validate the gage_id/calibrated-parameter short-circuit path."""
+
+    def test_successful_download_writes_patched_realization_json(
+        self, make_realization, monkeypatch, tmp_path
+    ):
+        """A 200 response must still result in config/realization.json being
+        written, with the placeholder time fields overwritten by the
+        caller-supplied start/end times (not left as the downloaded stub's
+        placeholder values)."""
+        fake_payload = {
+            "time": {
+                "start_time": "1900-01-01 00:00:00",
+                "end_time": "1900-01-02 00:00:00",
+                "output_interval": 3600,
+            },
+            "global": {"formulations": [{"params": {"model_type_name": "CFE"}}]},
+            "output_root": "./outputs/",
+        }
+
+        def fake_get(url, timeout=10):  # pylint: disable=unused-argument
+            return _FakeResponse(200, fake_payload)
+
+        monkeypatch.setattr(create_realization.requests, "get", fake_get)
+
+        result = make_realization(["sloth", "nom", "cfe"], gage_id="gage-01234567")
+
+        realization_path = tmp_path / "cat-test" / "config" / "realization.json"
+        assert realization_path.exists()
+        assert result["time"]["start_time"] == "2020-01-01 00:00:00"
+        assert result["time"]["end_time"] == "2020-01-02 00:00:00"
+        # Confirms the downloaded template (not the modular-registry template)
+        # was the basis for the written file.
+        assert result["output_root"] == "./outputs/"
+        # The old, dead-end filename should not be produced anymore.
+        assert not (tmp_path / "cat-test" / "config" / "downloaded_params.json").exists()
+
+    def test_failed_download_falls_back_to_modular_template(
+        self, make_realization, monkeypatch, tmp_path
+    ):
+        """A non-200 response must not short-circuit -- the normal modular
+        build (from MODEL_REGISTRY) still runs and produces realization.json."""
+
+        def fake_get(url, timeout=10):  # pylint: disable=unused-argument
+            return _FakeResponse(404)
+
+        monkeypatch.setattr(create_realization.requests, "get", fake_get)
+
+        result = make_realization(["sloth", "nom", "cfe"], gage_id="gage-01234567")
+
+        realization_path = tmp_path / "cat-test" / "config" / "realization.json"
+        assert realization_path.exists()
+        # The modular build stamps main_output_variable from the registry --
+        # the downloaded-template path would never set this key this way.
+        params = result["global"]["formulations"][0]["params"]
+        assert params["main_output_variable"] == MODEL_REGISTRY["cfe"].main_output_variable
+
+    def test_gage_id_ignored_for_non_matching_model_combo(self, make_realization, monkeypatch):
+        """The calibrated-parameter path only triggers for the exact
+        ["sloth", "nom", "cfe"] combination -- requests.get must not even be
+        called for any other model list, even with a gage_id set."""
+
+        def fake_get(url, timeout=10):  # pylint: disable=unused-argument
+            raise AssertionError("requests.get should not be called for this model combo")
+
+        monkeypatch.setattr(create_realization.requests, "get", fake_get)
+
+        result = make_realization(["sloth", "cfe"], gage_id="gage-01234567")
+        params = result["global"]["formulations"][0]["params"]
+        assert params["main_output_variable"] == MODEL_REGISTRY["cfe"].main_output_variable
+
+    def test_no_gage_id_never_calls_requests(self, make_realization, monkeypatch):
+        """Without a gage_id, the calibrated-parameter path must be skipped
+        entirely, regardless of the model combination."""
+
+        def fake_get(url, timeout=10):  # pylint: disable=unused-argument
+            raise AssertionError("requests.get should not be called without a gage_id")
+
+        monkeypatch.setattr(create_realization.requests, "get", fake_get)
+
+        result = make_realization(["sloth", "nom", "cfe"])
+        params = result["global"]["formulations"][0]["params"]
+        assert params["main_output_variable"] == MODEL_REGISTRY["cfe"].main_output_variable


### PR DESCRIPTION
## Summary
- `_handle_calibrated_params` downloaded a calibrated realization template for gages with SLoTH/NOM/CFE calibration data, but the caller returned immediately afterward without ever writing `config/realization.json` -- this path silently produced no realization file. It now patches the downloaded template's `time.start_time`/`time.end_time` with the caller-supplied times and writes it straight to `config/realization.json` (the old dead-end `downloaded_params.json` write is gone).
- Deduped `MODEL_DEPENDENCY_RULES`'s four near-identical standalone-model tuples (`lstm`, `lstm_rust`, `dhbv2`, `dhbv2_daily`) into a label map + shared predicate spliced in via a generator expression. Warning message strings are byte-identical to before.
- Deduped `dhbv2`/`dhbv2_daily`'s identical 9-entry `variables_names_map` into one shared module-level dict constant (safe because `ModelSpec` is frozen and callers always `copy.deepcopy` before mutating).
- Added test coverage for the calibrated-params path (successful download + patched write, failed download falling back to the modular build, non-matching model combo, and no-gage_id), which previously had zero coverage.

## Test plan
- [x] `uv run pytest -m "not integration"` -- 63 passed, including new calibrated-params tests and all existing golden-comparison tests (unaffected by the dedupe)
- [x] `uvx ruff@0.11.9 check modules/data_processing/create_realization.py tests/test_modular_realization.py` -- clean
- [x] `uvx ruff@0.11.9 format --check` on the same files -- clean

Scope: only `modules/data_processing/create_realization.py` and `tests/test_modular_realization.py` touched, per parallel-agent coordination on PR #245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)