### PR TITLE
Graft only model_params from calibrated gage templates

### DIFF
--- a/modules/data_processing/create_realization.py
+++ b/modules/data_processing/create_realization.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import logging
 import multiprocessing
@@ -763,6 +764,59 @@ def create_sacsma_realization(
     paths.setup_run_folders()
 
 
+# Modules whose parameters are produced by calibration. SLOTH is deliberately
+# excluded: the published files carry the same constants as the default template,
+# only serialised as strings, so copying them would regress the types.
+CALIBRATED_MODULES = ("NoahOWP", "CFE")
+
+
+def _bmi_modules(realization: dict) -> list:
+    """The BMI module list of a cfe-nom style realization, or [] if it has none."""
+    formulations = realization.get("global", {}).get("formulations", [])
+    if not formulations:
+        return []
+    return formulations[0].get("params", {}).get("modules", [])
+
+
+def graft_calibrated_model_params(default_template: dict, calibrated: dict) -> dict:
+    """Copy calibrated model_params onto the bundled default realization template.
+
+    Only the model_params blocks are taken from `calibrated`; every other key comes
+    from `default_template`. The published gage parameter files carry stale
+    scaffolding alongside the calibrated values - version pinned library_file paths,
+    missing forcing_file keys, extra keys the template does not use - and which
+    scaffolding is present varies from file to file, so it cannot be reliably
+    stripped. Building up from the default instead keeps the preprocessor's own
+    known good configuration and takes only what calibration actually produced.
+
+    Returns a new dict; neither argument is modified.
+    """
+    merged = copy.deepcopy(default_template)
+
+    calibrated_params = {}
+    for module in _bmi_modules(calibrated):
+        params = module.get("params", {})
+        if "model_type_name" in params and "model_params" in params:
+            calibrated_params[params["model_type_name"]] = params["model_params"]
+
+    grafted = []
+    for module in _bmi_modules(merged):
+        name = module.get("params", {}).get("model_type_name")
+        if name in CALIBRATED_MODULES and name in calibrated_params:
+            module["params"]["model_params"] = copy.deepcopy(calibrated_params[name])
+            grafted.append(name)
+
+    if grafted:
+        logger.debug(f"grafted calibrated model_params for {', '.join(grafted)}")
+    else:
+        logger.warning(
+            "calibrated template had no model_params for "
+            f"{' or '.join(CALIBRATED_MODULES)}, using the default template unchanged"
+        )
+
+    return merged
+
+
 def create_realization(
     cat_id: str,
     start_time: datetime,
@@ -780,10 +834,12 @@ def create_realization(
         url = f"https://communityhydrofabric.s3.us-east-1.amazonaws.com/hydrofabrics/community/gage_parameters/{gage_id}.json"
         response = requests.get(url)
         if response.status_code == 200:
-            new_template = requests.get(url).json()
+            with open(template_path, "r") as f:
+                default_template = json.load(f)
+            merged = graft_calibrated_model_params(default_template, response.json())
             template_path = paths.config_dir / "downloaded_params.json"
             with open(template_path, "w") as f:
-                json.dump(new_template, f)
+                json.dump(merged, f, indent=4)
             logger.info(f"downloaded calibrated parameters for {gage_id}")
         else:
             logger.warning(f"could not download parameters for {gage_id}, using default template")

--- a/tests/test_calibrated_params.py
+++ b/tests/test_calibrated_params.py
@@ -1,0 +1,131 @@
+"""Unit tests for grafting calibrated gage parameters onto the default template.
+
+Hermetic: both inputs are built in memory, nothing is downloaded.
+"""
+
+import copy
+import json
+import logging
+
+import pytest
+
+from data_processing.create_realization import (
+    CALIBRATED_MODULES,
+    graft_calibrated_model_params,
+)
+from data_processing.file_paths import FilePaths
+
+
+def _modules(realization):
+    return realization["global"]["formulations"][0]["params"]["modules"]
+
+
+def _module(realization, model_type_name):
+    return next(
+        m for m in _modules(realization) if m["params"]["model_type_name"] == model_type_name
+    )
+
+
+@pytest.fixture
+def default_template():
+    """The template the preprocessor ships."""
+    return json.loads(FilePaths.template_cfe_nowpm_realization_config.read_text())
+
+
+@pytest.fixture
+def calibrated(default_template):
+    """A published gage file: calibrated values plus the stale scaffolding.
+
+    Mirrors what is actually in the bucket -- see gage-10109001.json.
+    """
+    doc = copy.deepcopy(default_template)
+
+    sloth = _module(doc, "SLOTH")["params"]
+    sloth["library_file"] = "/dmod/shared_libs/libslothmodel.so.1.0.0"
+    sloth["model_params"] = {k: str(v) for k, v in sloth["model_params"].items()}
+
+    _module(doc, "NoahOWP")["params"]["model_params"] = {"CWP": 0.162, "MFSNO": 3.644}
+    _module(doc, "CFE")["params"]["model_params"] = {"b": 7.05, "satdk": 0.00072}
+
+    for module in _modules(doc):
+        module["params"].pop("forcing_file", None)
+        module["params"]["fixed_time_step"] = False
+
+    return doc
+
+
+def test_calibrated_values_are_grafted(default_template, calibrated):
+    merged = graft_calibrated_model_params(default_template, calibrated)
+
+    assert _module(merged, "NoahOWP")["params"]["model_params"] == {"CWP": 0.162, "MFSNO": 3.644}
+    assert _module(merged, "CFE")["params"]["model_params"] == {"b": 7.05, "satdk": 0.00072}
+
+
+def test_sloth_model_params_are_left_alone(default_template, calibrated):
+    """SLOTH's published values are the defaults stringified, so they are not copied."""
+    merged = graft_calibrated_model_params(default_template, calibrated)
+
+    assert (
+        _module(merged, "SLOTH")["params"]["model_params"]
+        == _module(default_template, "SLOTH")["params"]["model_params"]
+    )
+    assert all(
+        isinstance(v, float) for v in _module(merged, "SLOTH")["params"]["model_params"].values()
+    )
+
+
+def test_stale_scaffolding_is_not_carried_over(default_template, calibrated):
+    """Everything outside model_params comes from the default template."""
+    merged = graft_calibrated_model_params(default_template, calibrated)
+
+    assert (
+        _module(merged, "SLOTH")["params"]["library_file"] == "/dmod/shared_libs/libslothmodel.so"
+    )
+
+    # keys the published file adds must not appear, and keys it drops must survive
+    assert "fixed_time_step" not in _module(merged, "NoahOWP")["params"]
+    assert "forcing_file" in _module(merged, "NoahOWP")["params"]
+
+
+def test_only_model_params_differ_from_the_default(default_template, calibrated):
+    """Guards against anything else leaking in as the published files change."""
+    merged = graft_calibrated_model_params(default_template, calibrated)
+
+    for module in _modules(merged):
+        module["params"].pop("model_params", None)
+    for module in _modules(default_template):
+        module["params"].pop("model_params", None)
+
+    assert merged == default_template
+
+
+def test_inputs_are_not_mutated(default_template, calibrated):
+    before_default = copy.deepcopy(default_template)
+    before_calibrated = copy.deepcopy(calibrated)
+
+    graft_calibrated_model_params(default_template, calibrated)
+
+    assert default_template == before_default
+    assert calibrated == before_calibrated
+
+
+def test_template_without_calibrated_params_falls_back_and_warns(default_template, caplog):
+    """gage-10171000 publishes no model_params for either calibrated module."""
+    calibrated = copy.deepcopy(default_template)
+    for name in CALIBRATED_MODULES:
+        _module(calibrated, name)["params"].pop("model_params", None)
+
+    with caplog.at_level(logging.WARNING):
+        merged = graft_calibrated_model_params(default_template, calibrated)
+
+    assert merged == default_template
+    assert "no model_params" in caplog.text
+
+
+def test_unrecognised_template_shape_falls_back(default_template, caplog):
+    """A malformed download must not take the realization down with it."""
+    with caplog.at_level(logging.WARNING):
+        merged = graft_calibrated_model_params(default_template, {"not": "a realization"})
+
+    assert merged == default_template
+    assert "no model_params" in caplog.text


### PR DESCRIPTION
# Graft only model_params from calibrated gage templates

## Bug Fixed / Feature Added

Fixes #143.

When a gage has published calibrated parameters, `create_realization` downloaded that file and used it as the realization template wholesale. The published files carry stale scaffolding alongside the calibrated values, and all of it reached the generated `realization.json`:

- SLOTH `library_file` pinned to `libslothmodel.so.1.0.0` (29 of 57 published files) where the bundled template uses the unversioned `libslothmodel.so`
- SLOTH `model_params` serialised as strings – `"0.0"` rather than `0.0` (56 of 57) - `forcing_file` keys the bundled template carries, dropped
- extra keys the template does not use: `fixed_time_step` throughout, and `remotes_enabled` on `gage-10171000`

Only the `model_params` blocks on NoahOWP and CFE are actual calibration output.

## How it was fixed / implemented

`graft_calibrated_model_params()` starts from the bundled default template and copies in only the `model_params` blocks from the download, matching modules by `model_type_name`.

Building up from the default rather than stripping unwanted keys is deliberate: which scaffolding is present varies from file to file, so a deny-list cannot cover keys that have not appeared yet. Taking only what is wanted is immune to that.

SLOTH is excluded – its published values are the defaults stringified, so copying them gains nothing and would regress the type.

If the download carries no `model_params` for either module (`gage-10171000`), or is structurally unrecognisable, the default template is used unchanged and a warning is logged rather than failing the run.

The merge is a pure function over two dicts, so it is unit tested without network access. The `requests.get(url)` call was also being made twice; it now reuses the response.

Per the contributing guide: this affects **model behaviour, calibration, and reproducibility** – realizations for calibrated gages will differ from what previous versions produced.

## Testing / Screenshots

- New `tests/test_calibrated_params.py`: 7 hermetic tests covering the graft, the SLOTH exclusion, scaffolding rejection, input immutability, and both fallback paths.
- The 18 existing golden tests in `test_realization_templates.py` pass unchanged without `UPDATE_GOLDEN`, confirming the non-calibrated path is untouched.
- Full hermetic suite: 38 passed. 
- `ruff 0.11.9` check and format both clean.

<details>
<summary>Before/after: generated realization.json for gage-10109001</summary>

```diff
--- before (main): realization.json for gage-10109001
+++ after (this branch): realization.json for gage-10109001
@@ -10,7 +10,7 @@
                 "name": "bmi_multi",
                 "params": {
                     "allow_exceed_end_time": true,
-                    "fixed_time_step": false,
+                    "forcing_file": "",
                     "init_config": "",
                     "main_output_variable": "Q_OUT",
                     "model_type_name": "bmi_multi",
@@ -21,12 +21,12 @@
                                 "allow_exceed_end_time": true,
                                 "fixed_time_step": false,
                                 "init_config": "/dev/null",
-                                "library_file": "/dmod/shared_libs/libslothmodel.so.1.0.0",
+                                "library_file": "/dmod/shared_libs/libslothmodel.so",
                                 "main_output_variable": "z",
                                 "model_params": {
-                                    "sloth_ice_fraction_schaake(1,double,m,node)": "0.0",
-                                    "sloth_ice_fraction_xinanjiang(1,double,1,node)": "0.0",
-                                    "sloth_soil_moisture_profile(1,double,1,node)": "0.0"
+                                    "sloth_ice_fraction_schaake(1,double,m,node)": 0.0,
+                                    "sloth_ice_fraction_xinanjiang(1,double,1,node)": 0.0,
+                                    "sloth_soil_moisture_profile(1,double,1,node)": 0.0
                                 },
                                 "model_type_name": "SLOTH",
                                 "name": "bmi_c++",
@@ -38,7 +38,7 @@
                             "name": "bmi_fortran",
                             "params": {
                                 "allow_exceed_end_time": true,
-                                "fixed_time_step": false,
+                                "forcing_file": "",
                                 "init_config": "./config/cat_config/NOAH-OWP-M/{{id}}.input",
                                 "library_file": "/dmod/shared_libs/libsurfacebmi.so",
                                 "main_output_variable": "QINSUR",
</details>
```


_The calibrated model_params for NoahOWP and CFE do not appear in this diff – they are identical on both sides, which is the point._