### PR TITLE
add subset cli

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.venv
+.github
+*.png
+*.svg
+*.md
+*.cff

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM amazonlinux:2023 AS base
+COPY --from=ghcr.io/astral-sh/uv:0.12.3 /uv /uvx /bin/
+ENV UV_COMPILE_BYTECODE=1
+
+RUN dnf -y install python3.11 python3.11-devel cmake gcc gcc-c++ make geos geos-devel \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
+RUN ln -sf /usr/bin/python3.11 /usr/bin/python3 \
+    && ln -sf /usr/bin/python3.11 /usr/bin/python
+
+FROM base AS build
+
+RUN mkdir /app
+WORKDIR /app/
+RUN uv venv -p 3.11
+ENV PATH="/app/.venv/bin:$PATH"
+# appease exact-extract with the special scikit-build-core version
+# RUN echo "scikit-build-core<0.10" > /tmp/build-constraints.txt && \
+#     uv pip install -r pyproject.toml --build-constraint /tmp/build-constraints.txt
+COPY . .
+RUN uv build \
+    && echo "scikit-build-core<0.10" > /tmp/build-constraints.txt \
+    && uv pip install dist/ngiab_data_preprocess-*.whl --build-constraint /tmp/build-constraints.txt
+
+FROM amazonlinux:2023 AS runtime
+
+RUN dnf -y install python3.11 \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
+
+COPY --from=build /app/.venv /app/.venv
+ENV PATH="/app/.venv/bin:$PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,6 @@ WORKDIR /app/
 RUN uv venv -p 3.11
 ENV PATH="/app/.venv/bin:$PATH"
 # appease exact-extract with the special scikit-build-core version
-# RUN echo "scikit-build-core<0.10" > /tmp/build-constraints.txt && \
-#     uv pip install -r pyproject.toml --build-constraint /tmp/build-constraints.txt
 COPY . .
 RUN uv build \
     && echo "scikit-build-core<0.10" > /tmp/build-constraints.txt \

--- a/aws_tools/aws.dockerfile
+++ b/aws_tools/aws.dockerfile
@@ -2,9 +2,7 @@ FROM amazonlinux:2023 AS base
 COPY --from=ghcr.io/astral-sh/uv:0.12.3 /uv /uvx /bin/
 ENV UV_COMPILE_BYTECODE=1
 
-RUN dnf -y install python3.11 python3.11-devel cmake gcc gcc-c++ make geos geos-devel \
-    && dnf clean all \
-    && rm -rf /var/cache/dnf
+RUN dnf -y install python3.11 python3.11-devel cmake gcc gcc-c++ make geos geos-devel
 RUN ln -sf /usr/bin/python3.11 /usr/bin/python3 \
     && ln -sf /usr/bin/python3.11 /usr/bin/python
 

--- a/modules/data_processing/gpkg_utils.py
+++ b/modules/data_processing/gpkg_utils.py
@@ -254,12 +254,12 @@ def insert_data(con: sqlite3.Connection, table: str, contents: List[Tuple]) -> N
     con.commit()
 
 
-def update_geopackage_metadata(gpkg: Path) -> None:
+def update_geopackage_metadata(gpkg: Path, hydrofabric: Path = FilePaths.conus_hydrofabric) -> None:
     """
     Update the contents of the gpkg_contents table in the specified geopackage.
     """
     # table_name, data_type, identifier, description, last_change, min_x, min_y, max_x, max_y, srs_id
-    tables = get_feature_tables(FilePaths.conus_hydrofabric)
+    tables = get_feature_tables(hydrofabric)
     con = sqlite3.connect(gpkg)
     for table in tables:
         min_x = con.execute(f"SELECT MIN(minx) FROM rtree_{table}_geom").fetchone()[0]
@@ -334,7 +334,7 @@ def subset_table_by_vpu(table: str, vpu: str, hydrofabric: Path, subset_gpkg_nam
 
     insert_data(dest_db, table, contents)
 
-    if table in get_feature_tables(FilePaths.conus_hydrofabric):
+    if table in get_feature_tables(hydrofabric):
         fids = [str(x[0]) for x in contents]
         copy_rTree_tables(table, fids, source_db, dest_db)
 
@@ -387,7 +387,7 @@ def subset_table(table: str, ids: List[str], hydrofabric: Path, subset_gpkg_name
 
     insert_data(dest_db, table, contents)
 
-    if table in get_feature_tables(FilePaths.conus_hydrofabric):
+    if table in get_feature_tables(hydrofabric):
         fids = [str(x[0]) for x in contents]
         copy_rTree_tables(table, fids, source_db, dest_db)
 

--- a/modules/data_processing/graph_utils.py
+++ b/modules/data_processing/graph_utils.py
@@ -86,20 +86,26 @@ def create_graph_from_gpkg(hydrofabric: Path) -> ig.Graph:
 
 
 @cache
-def get_graph() -> ig.Graph:
+def get_graph(
+    gpkg_path: Path = FilePaths.conus_hydrofabric,
+    pickled_graph_path: Path = FilePaths.hydrofabric_graph
+) -> ig.Graph:
     """
     Attempts to load a graph from a pickled file; if unavailable, creates it from the geopackage.
 
     This function first checks if a pickled version of the graph exists. If not, it creates a new graph
     by reading hydrological data from a geopackage file and then pickles the newly created graph for future use.
 
+    Args:
+        gpkg_path (Path): The file path to the hydrofabric geopackage.
+        pickled_graph_path (Path): The file path to the pickled graph.
+
     Returns:
         ig.Graph: The hydrological network graph.
     """
-    pickled_graph_path = FilePaths.hydrofabric_graph
     if not pickled_graph_path.exists():
         logger.debug("Graph pickle does not exist, creating a new graph.")
-        network_graph = create_graph_from_gpkg(FilePaths.conus_hydrofabric)
+        network_graph = create_graph_from_gpkg(gpkg_path)
         network_graph.write_pickle(pickled_graph_path)
     else:
         try:
@@ -112,7 +118,11 @@ def get_graph() -> ig.Graph:
     return network_graph
 
 
-def get_outlet_id(wb_or_cat_id: str) -> str | None:
+def get_outlet_id(
+        wb_or_cat_id: str,
+        hydrofabric: Path = FilePaths.conus_hydrofabric,
+        pickled_graph_path: Path = FilePaths.hydrofabric_graph
+        ) -> str | None:
     """
     Retrieves the ID of the node downstream of the given node in the hydrological network.
 
@@ -122,7 +132,9 @@ def get_outlet_id(wb_or_cat_id: str) -> str | None:
     When finding the upstreams of a 'wb' waterbody or 'cat' catchment, what we actually want is the upstreams of the outlet of the 'wb'.
 
     Args:
-        name (str): The name of the node.
+        wb_or_cat_id (str): The ID of the waterbody or catchment.
+        hydrofabric (Path): The path to the hydrofabric geopackage.
+        pickled_graph_path (Path): The path to the pickled graph.
 
     Returns:
         str: The ID of the node downstream of the specified node.
@@ -131,7 +143,7 @@ def get_outlet_id(wb_or_cat_id: str) -> str | None:
     # remove everything that isn't a digit, then prepend wb- to get the graph node name
     stem = "".join(filter(str.isdigit, wb_or_cat_id))
     name = f"wb-{stem}"
-    graph = get_graph()
+    graph = get_graph(hydrofabric, pickled_graph_path)
     node_index = graph.vs.find(name=name).index
     # this returns the current node, and every node downstream of it in order
     downstream_node = graph.subcomponent(node_index, mode="OUT")
@@ -184,7 +196,12 @@ def get_upstream_cats(names: Union[str, List[str]]) -> Set[str]:
     return cat_ids
 
 
-def get_upstream_ids(names: Union[str, List[str]], include_outlet: bool = True) -> Set[str]:
+def get_upstream_ids(
+        names: Union[str, List[str]],
+        include_outlet: bool = True,
+        gpkg_path: Path = FilePaths.conus_hydrofabric,
+        pickled_graph_path: Path = FilePaths.hydrofabric_graph
+        ) -> Set[str]:
     """
     Retrieves IDs of all nodes upstream of, and including, the given nodes in the hydrological network.
 
@@ -193,17 +210,20 @@ def get_upstream_ids(names: Union[str, List[str]], include_outlet: bool = True) 
 
     Args:
         names (Union[str, List[str]]): A single node name or a list of node names.
+        include_outlet (bool): If True, includes the outlet node in the returned set. Defaults to True.
+        gpkg_path (Path): The path to the hydrofabric geopackage.
+        pickled_graph_path (Path): The path to the pickled graph.
 
     Returns:
         Set[str]: A list of IDs for all nodes upstream of the specified node(s). INCLUDING THE INPUT NODES.
     """
-    graph = get_graph()
+    graph = get_graph(gpkg_path, pickled_graph_path)
     if isinstance(names, str):
         names = [names]
     parent_ids = set()
     for name in names:
         if ("wb" in name or "cat" in name) and include_outlet:
-            name = get_outlet_id(name)
+            name = get_outlet_id(name, hydrofabric=gpkg_path, pickled_graph_path=pickled_graph_path)
         if name in parent_ids:
             continue
         try:

--- a/modules/data_processing/subset.py
+++ b/modules/data_processing/subset.py
@@ -69,7 +69,7 @@ def create_subset_gpkg(
             subset_table(table, ids, hydrofabric, output_gpkg_path)
 
     add_triggers_to_gpkg(output_gpkg_path)
-    update_geopackage_metadata(output_gpkg_path)
+    update_geopackage_metadata(output_gpkg_path, hydrofabric=hydrofabric)
 
 
 def subset_vpu(
@@ -100,7 +100,11 @@ def subset(
     include_outlet: bool = True,
     override_gpkg: bool = True,
 ):
-    upstream_ids = list(get_upstream_ids(cat_ids, include_outlet))
+    if hydrofabric != FilePaths.conus_hydrofabric:
+        pickled_graph_path = hydrofabric.parent / "hydrofabric_graph.gpickle"
+    else:
+        pickled_graph_path = FilePaths.hydrofabric_graph
+    upstream_ids = list(get_upstream_ids(cat_ids, include_outlet, hydrofabric, pickled_graph_path))
 
     if not output_gpkg_path:
         # if the name isn't provided, use the first upstream id

--- a/modules/ngiab_data_cli/subset_cli.py
+++ b/modules/ngiab_data_cli/subset_cli.py
@@ -50,6 +50,13 @@ def main() -> None:
         override_gpkg=True,
     )
 
+    logger.info(
+        "Subset complete for catchment %s from %s. Output saved to %s",
+        args.cat_id,
+        args.gpkg_path,
+        args.output_path
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/modules/ngiab_data_cli/subset_cli.py
+++ b/modules/ngiab_data_cli/subset_cli.py
@@ -9,6 +9,7 @@ from data_processing.subset import subset
 
 logger = logging.getLogger(__name__)
 
+
 def parse_arguments() -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description="Subsetting hydrofabrics")

--- a/modules/ngiab_data_cli/subset_cli.py
+++ b/modules/ngiab_data_cli/subset_cli.py
@@ -1,0 +1,54 @@
+"""Command line interface for subsetting geopackages by catchment ID."""
+
+import argparse
+import time
+from pathlib import Path
+import logging
+
+from data_processing.subset import subset
+
+logger = logging.getLogger(__name__)
+
+def parse_arguments() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Subsetting hydrofabrics")
+    parser.add_argument(
+        "--cat_id",
+        type=str,
+        help="ID of the catchment to subset",
+        required=True,
+    )
+    parser.add_argument(
+        "--gpkg_path",
+        type=Path,
+        help="path to the geopackage to subset",
+        required=True,
+    )
+    parser.add_argument(
+        "--output_path",
+        type=Path,
+        help="path to the output geopackage",
+        required=True,
+    )
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    """
+    Main function to run the subsetting process.
+    """
+    time.sleep(0.01)
+    args = parse_arguments()
+
+    subset(
+        cat_ids=args.cat_id,
+        hydrofabric=args.gpkg_path,
+        output_gpkg_path=args.output_path,
+        include_outlet=True,
+        override_gpkg=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ Issues = "https://github.com/CIROH-UA/NGIAB_data_preprocess/issues"
 cli = "ngiab_data_cli.__main__:main"
 map_app = "map_app.__main__:main"
 forcings = "ngiab_data_cli.forcing_cli:main"
+subset = "ngiab_data_cli.subset_cli:main"
 
 [build-system]
 # scm adds files tracked by git to the package


### PR DESCRIPTION
# Title
Add subset cli

## Bug Fixed / Feature Added
Add an alternate entry point to the module that only subsets user-provided geopackages according to a user-defined catchment ID

Removed graph functions' hardcoded assumption that we are always subsetting from the locally downloaded CONUS hydrofabric

Added Dockerfile to build a data preprocessor Docker image

## Testing
pytests passed 
subsetting functionality tested locally and verified visually
subsetting through `docker run` works!
```
docker run --rm -v "/Users/qylee/ngiab_preprocess_output/gage-10154200/config:/home/subset" ngiab_prep subset --cat_id cat-2863834 --gpkg_path /home/subset/gage-10154200_subset.gpkg --output_path /home/subset/cat-2863834.gpkg
```

## Notes
The docker image does not support the other CLI entrypoints (`cli`, `forcings`), because those require the locally downloaded CONUS hydrofabric and will try to prompt you in the terminal, which then kills the docker image because no response.

I would hope that the Docker image can continue to be reused in the datastream though, if we can add a CLI entrypoint for config and realization generation that doesn't rely on the CONUS hydrofabric! Definitely doable.

Closes #255 
